### PR TITLE
Fix the table to fit with the current terminal width

### DIFF
--- a/shell/Markdown.VT/Render/Extensions/VTTableRenderer.cs
+++ b/shell/Markdown.VT/Render/Extensions/VTTableRenderer.cs
@@ -19,17 +19,25 @@ namespace Markdown.VT;
 /// <seealso cref="VTObjectRenderer{Table}" />
 public class VTTableRenderer : VTObjectRenderer<Table>
 {
+    private readonly IAnsiConsole _myConsole;
+
+    public VTTableRenderer()
+    {
+        _myConsole = AnsiConsole.Create(
+            new AnsiConsoleSettings
+            {
+                Ansi = AnsiSupport.Detect,
+                ColorSystem = ColorSystemSupport.Detect,
+                Out = new AnsiConsoleOutput(Console.Out),
+            }
+        );
+    }
+
     protected override void Write(VTRenderer renderer, Table table)
     {
         var spectreTable = new Spectre.Console.Table()
             .LeftAligned()
             .MinimalBorder();
-
-        int consoleWidth = AnsiConsole.Profile.Width;
-        int indentWidth = renderer.GetIndentWidth();
-        // The table construct consumes 1 leading space and 1 trailing space.
-        // TODO: setting width this way may cause the table frame to be excessively long when the terminal width is large. Need to investigate.
-        spectreTable.Width(consoleWidth - indentWidth - 2);
 
         var sb = new StringBuilder();
         var newWriter = new StringWriter(sb);
@@ -77,7 +85,11 @@ public class VTTableRenderer : VTObjectRenderer<Table>
         }
 
         int start = 0;
-        string result = AnsiConsole.Console.ToAnsi(spectreTable);
+        int consoleWidth = AnsiConsole.Profile.Width;
+        int indentWidth = renderer.GetIndentWidth();
+
+        _myConsole.Profile.Width = consoleWidth - indentWidth;
+        string result = _myConsole.ToAnsi(spectreTable);
 
         renderer.WriteLine();
         while (true)


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Markdown rendering has indentations, which means the table rendering will have indentation as well. The extra indentation is unknown to `Spectre.Console`, which we use to generate the ANSI sequences for the table, and thus would cause the table row to be wrapped into the next line when the table's width is large.

I tried to fix this issue by setting `Width` of the table, but `Width` is not the max width, but means to use that exact width, which will result in a table to be unnecessarily too wide.

This is another fix to solve both problems, by having a private `AnsiConsole` whose width is changed based on the real terminal width and the indentation.