### PR TITLE
Improve code block rendering make it play well with the streaming render

### DIFF
--- a/shell/Markdown.VT/Render/Blocks/CodeBlockRenderer.cs
+++ b/shell/Markdown.VT/Render/Blocks/CodeBlockRenderer.cs
@@ -17,23 +17,23 @@ namespace Markdown.VT;
 public class CodeBlockRenderer : VTObjectRenderer<CodeBlock>
 {
     private readonly VTSyntaxHighlighter _vtHighlighter;
-    private readonly string _plainTextForeground;
-    private readonly string _plainTextBackground;
+    private readonly string _plainFgBgColors;
 
     public CodeBlockRenderer()
     {
         var styles = StyleDictionary.DefaultDark;
         if (styles.TryGetValue(ScopeName.PlainText, out Style style))
         {
-            _plainTextForeground = style.Foreground.ToVTColor();
-            _plainTextBackground = style.Background.ToVTColor(isForeground: false);
+            string foreground = style.Foreground.ToVTColor();
+            string background = style.Background.ToVTColor(isForeground: false);
+            _plainFgBgColors = $"{foreground}{background}";
         }
         _vtHighlighter = new VTSyntaxHighlighter(styles);
     }
 
     protected override void Write(VTRenderer renderer, CodeBlock obj)
     {
-        renderer.WriteLine($"{_plainTextForeground}{_plainTextBackground}");
+        renderer.WriteLine();
         renderer.PushIndentAndUpdateWidth(VTRenderer.DefaultIndent);
 
         ILanguage language = null;
@@ -41,45 +41,49 @@ public class CodeBlockRenderer : VTObjectRenderer<CodeBlock>
         {
             string infoPrefix = (obj.Parser as FencedCodeBlockParser)?.InfoPrefix ?? FencedCodeBlockParser.DefaultInfoPrefix;
             string langId = info.StartsWith(infoPrefix, StringComparison.Ordinal) ? info.Substring(infoPrefix.Length) : info;
-
-            language = _vtHighlighter.FindLanguageById(langId);
+            language = string.IsNullOrEmpty(langId) ? null : Languages.FindById(langId);
         }
 
         // Call the visitor with the original code.
         string code = ExtractCode(obj);
         renderer.Visitor?.VisitCodeBlock(code);
 
-        if (language is null)
-        {
-            renderer.WriteLeafRawLines(obj);
-        }
-        else
-        {
-            string vtText = _vtHighlighter.GetVTString(code, language);
+        int start = 0;
+        string vtText = _vtHighlighter.GetVTString(code, language);
 
-            int start = 0;
-            while (true)
+        while (true)
+        {
+            if (start == vtText.Length)
             {
-                if (start == vtText.Length)
-                {
-                    break;
-                }
-
-                int nlIndex = vtText.IndexOf('\n', start);
-                int length = nlIndex is -1 ? vtText.Length - start : nlIndex - start + 1;
-                var span = vtText.AsSpan(start, length);
-
-                // Call 'WriteLine' explicitly to make sure the indentation is applied.
-                renderer.Write(span.Trim('\n'));
-                renderer.WriteLine();
-
-                if (nlIndex is -1)
-                {
-                    break;
-                }
-
-                start = nlIndex + 1;
+                break;
             }
+
+            int nlIndex = vtText.IndexOf('\n', start);
+            int length = nlIndex is -1 ? vtText.Length - start : nlIndex - start + 1;
+            var span = vtText.AsSpan(start, length);
+
+            // We will write out indents before writing out lines of the decorated code blocks.
+            // If the line starts with the default foreground and background colors, then we
+            // move the color sequences up to before the indents.
+            if (span.StartsWith(_plainFgBgColors, StringComparison.Ordinal))
+            {
+                renderer.Writer.Write(_plainFgBgColors);
+                span = span[_plainFgBgColors.Length..];
+            }
+
+            // Call 'WriteLine' explicitly to make sure the indentation is applied.
+            // This is sort of an implementation detail: `render.Write` writes the indents only if the previous call
+            // wrote out a newline. So we call `Render.WriteLine` explicitly to make `Render` know that a newline was
+            // just written out.
+            renderer.Write(span.Trim('\n'));
+            renderer.WriteLine();
+
+            if (nlIndex is -1)
+            {
+                break;
+            }
+
+            start = nlIndex + 1;
         }
 
         renderer.PopIndentAndUpdateWidth();

--- a/shell/ShellCopilot.Kernel/Render.cs
+++ b/shell/ShellCopilot.Kernel/Render.cs
@@ -422,7 +422,11 @@ internal partial class StreamingRender
     private int SameUpTo(string newText, out bool redoWholeLine)
     {
         int i = 0;
-        for (; i < _currentText.Length; i++)
+
+        // Note that, `newText` is not necessarily longer than `_currentText`. After more chunks coming in, the trailing
+        // part of the raw text may now be considered a markdown structure and thus the new text may now be shorter than
+        // the current text.
+        for (; i < _currentText.Length && i < newText.Length; i++)
         {
             if (_currentText[i] != newText[i])
             {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Improve code block rendering make it play well with the streaming render.
The effort was put in maintaining the background color during rendering in the streaming manner.

The GIFs for comparison can be found below. The code block rendering in latter GIF looks much better.

**Before the changes**

![old-streaming](https://github.com/PowerShell/ShellCopilot/assets/127450/b2e52735-bb25-450f-926a-e2c184ee0895)

**After the changes**

![new-streaming](https://github.com/PowerShell/ShellCopilot/assets/127450/57cac667-0db1-4259-a2d2-97fea102ae7b)

