### PR TITLE
Support re-branding Shell Copilot to look like another application

### DIFF
--- a/shell/ShellCopilot.Abstraction/IHost.cs
+++ b/shell/ShellCopilot.Abstraction/IHost.cs
@@ -67,12 +67,27 @@ public interface IHost
     void RenderFullResponse(string response);
 
     /// <summary>
+    /// Render the passed-in objects in the table format, for all public readable properties of <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">Type of the passed-in object.</typeparam>
+    /// <param name="sources">Passed-in objects.</param>
+    void RenderTable<T>(IList<T> sources);
+
+    /// <summary>
     /// Render the passed-in objects in the table format.
     /// </summary>
     /// <typeparam name="T">Type of the passed-in object.</typeparam>
     /// <param name="sources">Passed-in objects.</param>
     /// <param name="elements">Header and value pairs to be rendered for each object.</param>
     void RenderTable<T>(IList<T> sources, IList<IRenderElement<T>> elements);
+
+    /// <summary>
+    /// Render the passed-in object out in the list format, for all public readable properties of <typeparamref name="T"/>,
+    /// or for all key/value pairs if <typeparamref name="T"/> implements <see cref="IDictionary{String, String}"/>.
+    /// </summary>
+    /// <typeparam name="T">Type of the passed-in object.</typeparam>
+    /// <param name="source">Passed-in object.</param>
+    void RenderList<T>(T source);
 
     /// <summary>
     /// Render the passed-in object out in the list format.

--- a/shell/ShellCopilot.Abstraction/ILLMAgent.cs
+++ b/shell/ShellCopilot.Abstraction/ILLMAgent.cs
@@ -1,5 +1,40 @@
-
 namespace ShellCopilot.Abstraction;
+
+/// <summary>
+/// Contract class for an application to warp around Shell Copilot.
+/// </summary>
+public class ShellWrapper
+{
+    /// <summary>
+    /// Name of the application to run from command line, e.g. 'az copilot'
+    /// </summary>
+    public string Name { set; get; }
+
+    /// <summary>
+    /// Banner text to use.
+    /// </summary>
+    public string Banner { set; get; }
+
+    /// <summary>
+    /// Version to show.
+    /// </summary>
+    public string Version { set; get; }
+
+    /// <summary>
+    /// The prompt text to use.
+    /// </summary>
+    public string Prompt { set; get; }
+
+    /// <summary>
+    /// The default agent to use, which should be available along with Shell Copilot.
+    /// </summary>
+    public string Agent { set; get; }
+
+    /// <summary>
+    /// Context information that can be passed into the agent.
+    /// </summary>
+    public Dictionary<string, string> Context { set; get; }
+}
 
 public enum RenderingStyle
 {
@@ -30,6 +65,11 @@ public class AgentConfig
     /// Sets and gets the preferred rendering style.
     /// </summary>
     public RenderingStyle RenderingStyle { set; get; }
+
+    /// <summary>
+    /// Sets and gets the context information for the agent that is passed into Shell Copilot.
+    /// </summary>
+    public Dictionary<string, string> Context { set; get; }
 }
 
 public interface ILLMAgent : IDisposable
@@ -43,6 +83,11 @@ public interface ILLMAgent : IDisposable
     /// Gets description of the agent.
     /// </summary>
     string Description { get; }
+
+    /// <summary>
+    /// Properties of the agent to be displayed to user.
+    /// </summary>
+    Dictionary<string, string> AgentInfo => null;
 
     /// <summary>
     /// Gets the path to the setting file of the agent.

--- a/shell/ShellCopilot.Abstraction/IRenderElement.cs
+++ b/shell/ShellCopilot.Abstraction/IRenderElement.cs
@@ -26,11 +26,49 @@ public sealed class PropertyElement<T> : IRenderElement<T>
         }
     }
 
+    public PropertyElement(PropertyInfo property)
+    {
+        ArgumentNullException.ThrowIfNull(property);
+
+        Type type = typeof(T);
+        if (type != property.ReflectedType)
+        {
+            throw new ArgumentException($"The passed-in property is not retrieved from the target type '{type.FullName}'.", nameof(property));
+        }
+
+        if (!_propertyInfo.CanRead)
+        {
+            throw new ArgumentException($"The property '{property.Name}' is write-only.", nameof(property));
+        }
+
+        _propertyName = property.Name;
+        _propertyInfo = property;
+    }
+
     public string Name => _propertyName;
     public string Value(T source)
     {
         ArgumentNullException.ThrowIfNull(source);
         return _propertyInfo.GetValue(source)?.ToString();
+    }
+}
+
+public sealed class KeyValueElement<T> : IRenderElement<T>
+    where T : IDictionary<string, string>
+{
+    private readonly string _key;
+
+    public KeyValueElement(string key)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(key);
+        _key = key;
+    }
+
+    public string Name => _key;
+    public string Value(T source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        return source.TryGetValue(_key, out string value) ? value : null;
     }
 }
 

--- a/shell/ShellCopilot.AzCLI.Agent/Agent.cs
+++ b/shell/ShellCopilot.AzCLI.Agent/Agent.cs
@@ -10,8 +10,9 @@ namespace ShellCopilot.AzCLI.Agent;
 public sealed class AzCLIAgent : ILLMAgent
 {
     public string Name => "az-cli";
-    public string Description => "An AI assistant to get the Azure CLI scripts or commands for management operations of Azure resources and the end-to-end scenarios containing multiple different Azure resources.";
-    public string SettingFile { private set; get; }
+    public string Description => "An AI assistant to provide Azure CLI scripts or commands for managing Azure resources and end-to-end scenarios that involve multiple Azure resources.";
+    public Dictionary<string, string> AgentInfo { private set; get; } = null;
+    public string SettingFile { private set; get; } = null;
 
     private const string SettingFileName = "az-cli.agent.json";
     private const string Endpoint = "https://cli-copilot-dogfood.azurewebsites.net/api/CopilotService";
@@ -19,6 +20,7 @@ public sealed class AzCLIAgent : ILLMAgent
     private bool _isInteractive;
     private string _configRoot;
     private RenderingStyle _renderingStyle;
+    private Dictionary<string, string> _context;
     private HttpClient _client;
     private StringBuilder _text;
     private string[] _scopes;
@@ -37,6 +39,19 @@ public sealed class AzCLIAgent : ILLMAgent
         _configRoot = config.ConfigurationRoot;
         _client = new HttpClient();
         _text = new StringBuilder();
+
+        _context = config.Context;
+        if (_context is not null)
+        {
+            _context.TryGetValue("tenant", out string tenantId);
+            _context.TryGetValue("subscription", out string subscriptionId);
+
+            AgentInfo = new Dictionary<string, string>
+            {
+                ["Tenant"] = tenantId,
+                ["Subscription"] = subscriptionId,
+            };
+        }
 
         _scopes = new[] { "api://62009369-df36-4df2-b7d7-b3e784b3ed55/" };
         _jsonOptions = new()

--- a/shell/ShellCopilot.Kernel/Command/AgentCommand.cs
+++ b/shell/ShellCopilot.Kernel/Command/AgentCommand.cs
@@ -2,7 +2,6 @@
 using System.CommandLine.Completions;
 using System.Diagnostics;
 using ShellCopilot.Abstraction;
-using Spectre.Console;
 
 namespace ShellCopilot.Kernel.Commands;
 
@@ -53,9 +52,9 @@ internal sealed class AgentCommand : CommandBase
             return;
         }
 
-        var current = chosenAgent.Impl;
         shell.SwitchActiveAgent(chosenAgent);
-        shell.Host.MarkupLine($"Using the agent [green]{current.Name}[/]:\n[italic]{current.Description.EscapeMarkup()}[/]\n");
+        shell.Host.MarkupLine($"Using the agent [green]{chosenAgent.Impl.Name}[/]:");
+        chosenAgent.Display(shell.Host);
     }
 
     private void PopAgentAction()
@@ -66,8 +65,9 @@ internal sealed class AgentCommand : CommandBase
         {
             shell.PopActiveAgent();
 
-            var current = shell.ActiveAgent.Impl;
-            shell.Host.MarkupLine($"Using the agent [green]{current.Name}[/]:\n[italic]{current.Description.EscapeMarkup()}[/]\n");
+            var current = shell.ActiveAgent;
+            shell.Host.MarkupLine($"Using the agent [green]{current.Impl.Name}[/]:");
+            current.Display(shell.Host);
         }
         catch (Exception ex)
         {

--- a/shell/ShellCopilot.Kernel/LLMAgent.cs
+++ b/shell/ShellCopilot.Kernel/LLMAgent.cs
@@ -1,4 +1,5 @@
 ﻿using ShellCopilot.Abstraction;
+using Spectre.Console;
 
 namespace ShellCopilot.Kernel;
 
@@ -14,6 +15,19 @@ internal class LLMAgent
 
         OrchestratorRoleDisabled = false;
         AnalyzerRoleDisabled = false;
+    }
+
+    internal void Display(Host host)
+    {
+        host.MarkupLine($"[italic]{Impl.Description.EscapeMarkup()}[/]");
+        if (Impl.AgentInfo is null || Impl.AgentInfo.Count is 0)
+        {
+            host.WriteLine();
+        }
+        else
+        {
+            host.RenderList(Impl.AgentInfo);
+        }
     }
 
     internal bool IsOrchestrator(out IOrchestrator orchestrator)

--- a/shell/ShellCopilot.Kernel/Utility/ReadLineHelper.cs
+++ b/shell/ShellCopilot.Kernel/Utility/ReadLineHelper.cs
@@ -70,7 +70,7 @@ internal class ReadLineHelper : IReadLineHelper
             if (regex.IsMatch(name))
             {
                 result ??= new();
-                result.Add(new CompletionResult(name, name, CompletionResultType.Command, toolTip: null));
+                result.Add(new CompletionResult(name, name, CompletionResultType.Command, toolTip: entry.Value.Description));
             }
         }
 

--- a/shell/ShellCopilot.OpenAI.Agent/Agent.cs
+++ b/shell/ShellCopilot.OpenAI.Agent/Agent.cs
@@ -206,9 +206,10 @@ public sealed class OpenAIAgent : ILLMAgent
             using var stream = new FileStream(SettingFile, FileMode.Open, FileAccess.Read, FileShare.Read);
             var options = new JsonSerializerOptions
             {
-                Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) },
+                AllowTrailingCommas = true,
                 ReadCommentHandling = JsonCommentHandling.Skip,
-                AllowTrailingCommas = true
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) },
             };
             var data = JsonSerializer.Deserialize<ConfigData>(stream, options);
             settings = new Settings(data);

--- a/shell/ShellCopilot.OpenAI.Agent/Service.cs
+++ b/shell/ShellCopilot.OpenAI.Agent/Service.cs
@@ -53,9 +53,10 @@ internal class ChatService
             using var stream = new FileStream(historyFile, FileMode.Open, FileAccess.Read, FileShare.Read);
             var options = new JsonSerializerOptions
             {
-                Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) },
+                AllowTrailingCommas = true,
                 ReadCommentHandling = JsonCommentHandling.Skip,
-                AllowTrailingCommas = true
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) },
             };
 
             _chatHistory = JsonSerializer.Deserialize<List<ChatMessage>>(stream, options);


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Support re-branding Shell Copilot to look like another application.

The option `--shell-wrapper` is added to support wrapping Shell Copilot as another application. Example:

![image](https://github.com/PowerShell/ShellCopilot/assets/127450/db346a1c-ae51-4ace-9451-4d742b05043f)

The `ShellWrapper` type defines the contract of the JSON. The `context` field is a dictionary that can contain arbitrary key/value pairs. The dictionary will be passed on to the corresponding agent (`az-cli` agent in this case).
```
{
  "name": "az copilot",
  "banner": "Azure CLI Copilot",
  "version": "v0.1",
  "prompt": "Copilot",
  "agent": "az-cli",
  "context": {
    "tenant": "00000000-0000-0000-0000-000000000000",
    "subscription": "00000000-0000-0000-0000-000000000000"
  }
}
```

**No schema validation today, which should be put in our backlog.**