### PR TITLE
Add 'regen' command and support using clipboard content as context information

### DIFF
--- a/shell/ShellCopilot.AzCLI.Agent/Agent.cs
+++ b/shell/ShellCopilot.AzCLI.Agent/Agent.cs
@@ -122,10 +122,7 @@ public sealed class AzCLIAgent : ILLMAgent
 
         var data = azResponse.Data[0];
         _text.Clear();
-        _text.AppendLine($"### {data.Scenario}")
-            .AppendLine()
-            .AppendLine(data.Description)
-            .AppendLine();
+        _text.AppendLine(data.Description).AppendLine();
 
         if (data.CommandSet.Count > 0)
         {
@@ -143,7 +140,7 @@ public sealed class AzCLIAgent : ILLMAgent
             }
             _text.AppendLine("```")
                 .AppendLine()
-                .AppendLine("Make sure to replace the argument values used above as appropriate.");
+                .AppendLine("Make sure to replace the placeholder values with your specific details.");
         }
 
         host.RenderFullResponse(_text.ToString());

--- a/shell/ShellCopilot.Kernel/Command/CommandRunner.cs
+++ b/shell/ShellCopilot.Kernel/Command/CommandRunner.cs
@@ -30,6 +30,7 @@ internal class CommandRunner
             new ClearCommand(),
             new CodeCommand(),
             new ExitCommand(),
+            new RegenCommand(),
             new HelpCommand(),
         };
 

--- a/shell/ShellCopilot.Kernel/Command/RegenCommand.cs
+++ b/shell/ShellCopilot.Kernel/Command/RegenCommand.cs
@@ -1,0 +1,26 @@
+﻿using System.CommandLine;
+using ShellCopilot.Abstraction;
+
+namespace ShellCopilot.Kernel.Commands;
+
+internal sealed class RegenCommand : CommandBase
+{
+    public RegenCommand()
+        : base("regen", "Regenerate a new response for the last query.")
+    {
+        this.SetHandler(RegenAction);
+    }
+
+    private void RegenAction()
+    {
+        var shell = (Shell)Shell;
+
+        if (shell.LastQuery is null)
+        {
+            shell.Host.MarkupErrorLine($"No previous query available.");
+            return;
+        }
+
+        shell.Regenerate = true;
+    }
+}

--- a/shell/ShellCopilot.Kernel/Host.cs
+++ b/shell/ShellCopilot.Kernel/Host.cs
@@ -387,7 +387,7 @@ internal sealed class Host : IHost
         RequireStdoutOrStderr(operation);
 
         IAnsiConsole ansiConsole = _outputRedirected ? _stderrConsole : AnsiConsole.Console;
-        var confirmation = new ConfirmationPrompt(prompt) { DefaultValue = defaultValue };
+        var confirmation = new ConfirmationPrompt($"[orange3 on italic]{prompt.EscapeMarkup()}[/]") { DefaultValue = defaultValue };
 
         return await confirmation.ShowAsync(ansiConsole, cancellationToken).ConfigureAwait(false);
     }
@@ -407,6 +407,25 @@ internal sealed class Host : IHost
             .Secret()
             .ShowAsync(ansiConsole, cancellationToken)
             .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Render text content in the "for-reference" style.
+    /// </summary>
+    /// <param name="header">Title for the content.</param>
+    /// <param name="content">Text to be rendered.</param>
+    internal void RenderReferenceText(string header, string content)
+    {
+        RequireStdoutOrStderr(operation: "Render reference");
+
+        var panel = new Panel($"\n[italic]{content.EscapeMarkup()}[/]\n")
+            .RoundedBorder()
+            .BorderColor(Color.DarkCyan)
+            .Header($"[orange3 on italic] {header.Trim()} [/]");
+
+        AnsiConsole.WriteLine();
+        AnsiConsole.Write(panel);
+        AnsiConsole.WriteLine();
     }
 
     /// <summary>


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

- Add 'regen' command to regenerate for the last query.
- Support proactively using clipboard content as context information.

