### PR TITLE
Use separate `AssemblyLoadContext` for every agent plugin

### DIFF
--- a/shell/ShellCopilot.Kernel/LLMAgent.cs
+++ b/shell/ShellCopilot.Kernel/LLMAgent.cs
@@ -6,12 +6,14 @@ namespace ShellCopilot.Kernel;
 internal class LLMAgent
 {
     internal ILLMAgent Impl { get; }
+    internal AgentAssemblyLoadContext LoadContext { get; }
     internal bool OrchestratorRoleDisabled { set; get; }
     internal bool AnalyzerRoleDisabled { set; get; }
 
-    internal LLMAgent(ILLMAgent agent)
+    internal LLMAgent(ILLMAgent agent, AgentAssemblyLoadContext loadContext)
     {
         Impl = agent;
+        LoadContext = loadContext;
 
         OrchestratorRoleDisabled = false;
         AnalyzerRoleDisabled = false;

--- a/shell/ShellCopilot.Kernel/Shell.cs
+++ b/shell/ShellCopilot.Kernel/Shell.cs
@@ -96,9 +96,11 @@ internal sealed class Shell : IShell
     /// <summary>
     /// Load a plugin assembly file and process the agents defined in it.
     /// </summary>
-    internal void ProcessAgentPlugin(string pluginFile)
+    internal void ProcessAgentPlugin(string pluginName, string pluginDir, string pluginFile)
     {
-        Assembly plugin = Assembly.LoadFrom(pluginFile);
+        AgentAssemblyLoadContext context = new(pluginName, pluginDir);
+        Assembly plugin = context.LoadFromAssemblyPath(pluginFile);
+
         foreach (Type type in plugin.ExportedTypes)
         {
             if (!typeof(ILLMAgent).IsAssignableFrom(type))
@@ -121,7 +123,7 @@ internal sealed class Shell : IShell
             };
 
             agent.Initialize(config);
-            _agents.Add(new LLMAgent(agent));
+            _agents.Add(new LLMAgent(agent, context));
         }
     }
 
@@ -147,7 +149,7 @@ internal sealed class Shell : IShell
 
             try
             {
-                ProcessAgentPlugin(file);
+                ProcessAgentPlugin(name, dir, file);
             }
             catch (Exception ex)
             {

--- a/shell/ShellCopilot.Kernel/Utility/Clipboard.cs
+++ b/shell/ShellCopilot.Kernel/Utility/Clipboard.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 

--- a/shell/ShellCopilot.Kernel/Utility/LoadContext.cs
+++ b/shell/ShellCopilot.Kernel/Utility/LoadContext.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.Loader;
+
+namespace ShellCopilot.Kernel;
+
+internal class AgentAssemblyLoadContext : AssemblyLoadContext
+{
+    private readonly string _dependencyDir;
+
+    internal AgentAssemblyLoadContext(string name, string dependencyDir)
+        : base($"{name.Replace(' ', '.')}-ALC", isCollectible: false)
+    {
+        if (!Directory.Exists(dependencyDir))
+        {
+            throw new ArgumentException($"The agent home directory '{dependencyDir}' doesn't exist.", nameof(dependencyDir));
+        }
+
+        // Save the full path to the dependencies directory when creating the context.
+        _dependencyDir = dependencyDir;
+    }
+
+    protected override Assembly Load(AssemblyName assemblyName)
+    {
+        // Create a path to the assembly in the dependencies directory.
+        string path = Path.Combine(_dependencyDir, $"{assemblyName.Name}.dll");
+
+        if (File.Exists(path))
+        {
+            // If the assembly exists in our dependency directory, then load it into this load context.
+            return LoadFromAssemblyPath(path);
+        }
+
+        // Otherwise we will depend on the default load context to resolve the request.
+        return null;
+    }
+}


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Use separate `AssemblyLoadContext` for every agent plugin.
This is strongly needed to avoid assembly loading conflicts when different agents bring in dependencies on different versions of the same assemblies.

With this change, the `openai-gpt` agent can unchanged when another agent depends on newer versions of the `Azure.AI.OpenAI` package, which introduced breaking changes.