### PR TITLE
Improve the syntax highlighting for bash script

### DIFF
--- a/shell/Markdown.VT/ColorCode.VT/Parser/Bash.cs
+++ b/shell/Markdown.VT/ColorCode.VT/Parser/Bash.cs
@@ -19,6 +19,41 @@ public class Bash : ILanguage
                 {
                     {1, ScopeName.Comment}
                 }),
+
+            // match the first word of a line in a multi-line string as the command name.
+            new LanguageRule(
+                @"(?m)^\s*(\w+)",
+                new Dictionary<int, string>
+                {
+                    {1, ScopeName.PowerShellCommand}
+                }),
+
+            // match options like '-word'
+            new LanguageRule(
+                @"\s+-\w+",
+                new Dictionary<int, string>
+                    {
+                        {0, ScopeName.PowerShellParameter}
+                    }
+                ),
+
+            // match options like '--word', '--word-word', '--word-word-word' and etc.
+            new LanguageRule(
+                @"\s+--(?:\w+-?)+",
+                new Dictionary<int, string>
+                    {
+                        {0, ScopeName.PowerShellParameter}
+                    }
+                ),
+
+            // match variable like '$word', '$digit', '$word_word' and etc.
+            new LanguageRule(
+                @"\$(?:[\d\w]+_?)+",
+                new Dictionary<int, string>
+                    {
+                        {0, ScopeName.PowerShellVariable}
+                    }
+                ),
         };
 
     public bool HasAlias(string lang)


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Improve the syntax highlighting for bash script by detecting
- command name
- parameters/options
- variables

New look after the enhancement

![image](https://github.com/PowerShell/ShellCopilot/assets/127450/0ee53ba4-4e51-42bc-afd4-d3afc372cbb0)

![image](https://github.com/PowerShell/ShellCopilot/assets/127450/88e5298e-fe90-4a63-bf86-24dada244b47)

