### PR TITLE
Update to use the bat theme for PowerShell syntax highlighting

### DIFF
--- a/shell/Markdown.VT/ColorCode.VT/VTSyntaxHighlighter.cs
+++ b/shell/Markdown.VT/ColorCode.VT/VTSyntaxHighlighter.cs
@@ -31,7 +31,7 @@ public class VTSyntaxHighlighter : CodeColorizerBase
     /// <param name="styles">The Custom styles to Apply to the formatted Code.</param>
     /// <param name="languageParser">The language parser that the <see cref="VTSyntaxHighlighter"/> instance will use for its lifetime.</param>
     public VTSyntaxHighlighter(StyleDictionary styles = null, ILanguageParser languageParser = null)
-        : base(styles, languageParser)
+        : base(styles.UseBatStyle(), languageParser)
     {
         _buffer = new StringBuilder(capacity: 512);
 
@@ -200,6 +200,49 @@ public class VTSyntaxHighlighter : CodeColorizerBase
 
 public static class ColorExtensionMethods
 {
+    /// <summary>
+    /// Use the style from 'bat' for PowerShell syntax highlighting.
+    /// </summary>
+    internal static StyleDictionary UseBatStyle(this StyleDictionary styles)
+    {
+        if (styles is null)
+        {
+            return null;
+        }
+
+        styles.Remove(ScopeName.String);
+        styles.Remove(ScopeName.Comment);
+        styles.Remove(ScopeName.PowerShellOperator);
+        styles.Remove(ScopeName.PowerShellVariable);
+
+        styles.Add(
+            new Style(ScopeName.String)
+            {
+                Foreground = "\x1b[38;5;186m",
+                ReferenceName = "string"
+            });
+        styles.Add(
+            new Style(ScopeName.Comment)
+            {
+                Foreground = "\x1b[38;5;242m",
+                ReferenceName = "comment"
+            });
+        styles.Add(
+            new Style(ScopeName.PowerShellOperator)
+            {
+                Foreground = "\x1b[38;5;203m",
+                ReferenceName = "powershellOperator"
+            });
+        styles.Add(
+            new Style(ScopeName.PowerShellVariable)
+            {
+                Foreground = "\x1b[92m",
+                ReferenceName = "powershellVariable"
+            });
+
+        return styles;
+    }
+
     public static string ToVTColor(this string color, bool isForeground = true)
     {
         if (color == null)


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Received feedback about the default colors used for PowerShell syntax highlighting is too distracting.
So, update to use the bat theme for PowerShell syntax highlighting for now.

![image](https://github.com/PowerShell/ShellCopilot/assets/127450/f648d7d0-a16f-40d9-a9d3-0c399a536722)

![image](https://github.com/PowerShell/ShellCopilot/assets/127450/f7e91a5f-4509-4497-b56f-9c7ec19b5a00)

![image](https://github.com/PowerShell/ShellCopilot/assets/127450/e937d170-37c7-49c7-98f4-209760fbd35b)

