### PR TITLE
Add history support to the `AzCLI` agent

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -56,7 +56,7 @@ if ($LASTEXITCODE -eq 0) {
 }
 
 if ($LASTEXITCODE -eq 0) {
-    Write-Host "`n[Build the Azure agent ...]`n" -ForegroundColor Green
+    Write-Host "`n[Build the Azure agents ...]`n" -ForegroundColor Green
     $az_csproj = GetProjectFile $az_agent_dir
     dotnet publish $az_csproj -c $Configuration -o $az_out_dir
 }

--- a/shell/ShellCopilot.Azure.Agent/AzCLI/AzCLIAgent.cs
+++ b/shell/ShellCopilot.Azure.Agent/AzCLI/AzCLIAgent.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using System.Text.Json;
 using Azure.Identity;
 using ShellCopilot.Abstraction;
 
@@ -76,6 +77,14 @@ public sealed class AzCLIAgent : ILLMAgent
                 }
 
                 var data = azResponse.Data[0];
+                var history = _chatService.ChatHistory;
+                while (history.Count > Utils.HistoryCount - 2)
+                {
+                    history.RemoveAt(0);
+                }
+                history.Add(new ChatMessage { Role = "user", Content = input });
+                history.Add(new ChatMessage { Role = "assistant", Content = JsonSerializer.Serialize(data, Utils.JsonOptions) });
+
                 _text.Clear();
                 _text.AppendLine(data.Description).AppendLine();
 

--- a/shell/ShellCopilot.Azure.Agent/AzCLI/AzCLIChatService.cs
+++ b/shell/ShellCopilot.Azure.Agent/AzCLI/AzCLIChatService.cs
@@ -13,14 +13,18 @@ internal class AzCLIChatService : IDisposable
 
     private readonly HttpClient _client;
     private readonly string[] _scopes;
+    private readonly List<ChatMessage> _chatHistory;
     private AccessToken? _accessToken;
 
     internal AzCLIChatService()
     {
         _client = new HttpClient();
         _scopes = ["api://62009369-df36-4df2-b7d7-b3e784b3ed55/"];
+        _chatHistory = [];
         _accessToken = null;
     }
+
+    internal List<ChatMessage> ChatHistory => _chatHistory;
 
     public void Dispose()
     {
@@ -51,7 +55,12 @@ internal class AzCLIChatService : IDisposable
 
     private HttpRequestMessage PrepareForChat(string input)
     {
-        var requestData = new Query { Question = input, Top_num = 1 };
+        var requestData = new Query
+        {
+            Question = input,
+            History = _chatHistory,
+            Top_num = 1
+        };
         var json = JsonSerializer.Serialize(requestData, Utils.JsonOptions);
 
         var content = new StringContent(json, Encoding.UTF8, "application/json");

--- a/shell/ShellCopilot.Azure.Agent/AzCLI/AzCLISchema.cs
+++ b/shell/ShellCopilot.Azure.Agent/AzCLI/AzCLISchema.cs
@@ -3,6 +3,7 @@ namespace ShellCopilot.Azure.CLI;
 internal class Query
 {
     public string Question { get; set; }
+    public List<ChatMessage> History { get; set; }
     public int Top_num { get; set; }
 }
 

--- a/shell/ShellCopilot.Azure.Agent/AzPS/AzPSChatService.cs
+++ b/shell/ShellCopilot.Azure.Agent/AzPS/AzPSChatService.cs
@@ -41,6 +41,10 @@ internal class AzPSChatService : IDisposable
     {
         if (!string.IsNullOrEmpty(response))
         {
+            while (_chatHistory.Count > Utils.HistoryCount - 1)
+            {
+                _chatHistory.RemoveAt(0);
+            }
             _chatHistory.Add(new ChatMessage() { Role = "assistant", Content = response });
         }
     }

--- a/shell/ShellCopilot.Azure.Agent/AzPS/AzPSSchema.cs
+++ b/shell/ShellCopilot.Azure.Agent/AzPS/AzPSSchema.cs
@@ -3,12 +3,6 @@ using System.Text.Json.Serialization;
 
 namespace ShellCopilot.Azure.PowerShell;
 
-internal class ChatMessage
-{
-    public string Role { get; set; }
-    public string Content { get; set; }
-}
-
 internal class Query
 {
     public List<ChatMessage> Messages { get; set; }

--- a/shell/ShellCopilot.Azure.Agent/Utils.cs
+++ b/shell/ShellCopilot.Azure.Agent/Utils.cs
@@ -16,6 +16,11 @@ internal static class Utils
     }
 
     internal static JsonSerializerOptions JsonOptions => s_jsonOptions;
+
+    /// <summary>
+    /// Keep 3 conversation iterations as the context information.
+    /// </summary>
+    internal const int HistoryCount = 6;
 }
 
 internal class RefreshTokenException : Exception
@@ -24,4 +29,10 @@ internal class RefreshTokenException : Exception
         : base(message, innerException)
     {
     }
+}
+
+internal class ChatMessage
+{
+    public string Role { get; set; }
+    public string Content { get; set; }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Add history support to the `AzCLI` agent.
For now, both `AzPS` and `AzCLI` agents keep 3 rounds of conversation iterations as the context information.

