### PR TITLE
Remove `MarkupErrorLine` and move its logic to `WriteErrorLine`

### DIFF
--- a/shell/ShellCopilot.Abstraction/IHost.cs
+++ b/shell/ShellCopilot.Abstraction/IHost.cs
@@ -23,7 +23,8 @@ public interface IHost
     IHost WriteErrorLine();
 
     /// <summary>
-    /// Write out the string literally to stderr with a new line.
+    /// Write out the error string to stderr with a new line.
+    /// Format the error string in red color when stderr is not redirected.
     /// </summary>
     IHost WriteErrorLine(string value);
 
@@ -36,11 +37,6 @@ public interface IHost
     /// Write out the markup string to stdout with a new line.
     /// </summary>
     IHost MarkupLine(string value);
-
-    /// <summary>
-    /// Write out an error to stderr with the passed-in markup string.
-    /// </summary>
-    IHost MarkupErrorLine(string value);
 
     /// <summary>
     /// Write out a note with the passed-in markup string.

--- a/shell/ShellCopilot.Abstraction/ShellCopilot.Abstraction.csproj
+++ b/shell/ShellCopilot.Abstraction/ShellCopilot.Abstraction.csproj
@@ -8,7 +8,7 @@
     <GenerateDependencyFile>false</GenerateDependencyFile>
 
     <PackageId>ShellCopilot.Abstraction</PackageId>
-    <Version>0.1.0-beta.4</Version>
+    <Version>0.1.0-beta.5</Version>
     <Authors>Microsoft</Authors>
     <Company>Your Company</Company>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/shell/ShellCopilot.Azure.Agent/AzCLI/AzCLIAgent.cs
+++ b/shell/ShellCopilot.Azure.Agent/AzCLI/AzCLIAgent.cs
@@ -66,13 +66,13 @@ public sealed class AzCLIAgent : ILLMAgent
             {
                 if (azResponse.Error is not null)
                 {
-                    host.MarkupErrorLine(azResponse.Error);
+                    host.WriteErrorLine(azResponse.Error);
                     return true;
                 }
 
                 if (azResponse.Data.Count is 0)
                 {
-                    host.MarkupErrorLine("Sorry, no response received.");
+                    host.WriteErrorLine("Sorry, no response received.");
                     return true;
                 }
 
@@ -114,12 +114,12 @@ public sealed class AzCLIAgent : ILLMAgent
             Exception inner = ex.InnerException;
             if (inner is CredentialUnavailableException)
             {
-                host.MarkupErrorLine($"Access token not available. Query cannot be served.");
-                host.MarkupErrorLine($"The '{Name}' agent depends on the Azure CLI credential to acquire access token. Please run 'az login' from a command-line shell to setup account.");
+                host.WriteErrorLine($"Access token not available. Query cannot be served.");
+                host.WriteErrorLine($"The '{Name}' agent depends on the Azure CLI credential to acquire access token. Please run 'az login' from a command-line shell to setup account.");
             }
             else
             {
-                host.MarkupErrorLine($"Failed to get the access token. {inner.Message}");
+                host.WriteErrorLine($"Failed to get the access token. {inner.Message}");
             }
 
             return false;

--- a/shell/ShellCopilot.Azure.Agent/AzPS/AzPSAgent.cs
+++ b/shell/ShellCopilot.Azure.Agent/AzPS/AzPSAgent.cs
@@ -94,12 +94,12 @@ public sealed class AzPSAgent : ILLMAgent
             Exception inner = ex.InnerException;
             if (inner is CredentialUnavailableException)
             {
-                host.MarkupErrorLine($"Access token not available. Query cannot be served.");
-                host.MarkupErrorLine($"The '{Name}' agent depends on the Azure PowerShell credential to acquire access token. Please run 'Connect-AzAccount' from a command-line shell to setup account.");
+                host.WriteErrorLine($"Access token not available. Query cannot be served.");
+                host.WriteErrorLine($"The '{Name}' agent depends on the Azure PowerShell credential to acquire access token. Please run 'Connect-AzAccount' from a command-line shell to setup account.");
             }
             else
             {
-                host.MarkupErrorLine($"Failed to get the access token. {inner.Message}");
+                host.WriteErrorLine($"Failed to get the access token. {inner.Message}");
             }
 
             return false;

--- a/shell/ShellCopilot.Azure.Agent/ShellCopilot.Azure.Agent.csproj
+++ b/shell/ShellCopilot.Azure.Agent/ShellCopilot.Azure.Agent.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.10.4" />
-    <PackageReference Include="ShellCopilot.Abstraction" Version="0.1.0-beta.4">
+    <PackageReference Include="ShellCopilot.Abstraction" Version="0.1.0-beta.5">
       <ExcludeAssets>contentFiles</ExcludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/shell/ShellCopilot.Kernel/Command/AgentCommand.cs
+++ b/shell/ShellCopilot.Kernel/Command/AgentCommand.cs
@@ -71,7 +71,7 @@ internal sealed class AgentCommand : CommandBase
         }
         catch (Exception ex)
         {
-            shell.Host.MarkupErrorLine(ex.Message);
+            shell.Host.WriteErrorLine(ex.Message);
         }
     }
 
@@ -91,7 +91,7 @@ internal sealed class AgentCommand : CommandBase
         var current = chosenAgent.Impl;
         if (current.SettingFile is null)
         {
-            shell.Host.MarkupErrorLine($"The agent '{current.Name}' doesn't support configuration.");
+            shell.Host.WriteErrorLine($"The agent '{current.Name}' doesn't support configuration.");
             return;
         }
 
@@ -107,7 +107,7 @@ internal sealed class AgentCommand : CommandBase
         }
         catch (Exception ex)
         {
-            shell.Host.MarkupErrorLine(ex.Message);
+            shell.Host.WriteErrorLine(ex.Message);
         }
     }
 
@@ -124,7 +124,7 @@ internal sealed class AgentCommand : CommandBase
     private static void AgentNotFound(string name, Shell shell)
     {
         string availableAgentNames = string.Join(',', shell.Agents.Select(AgentName));
-        shell.Host.MarkupErrorLine($"Cannot find an agent with the name '{name}'. Available agent(s): {availableAgentNames}");
+        shell.Host.WriteErrorLine($"Cannot find an agent with the name '{name}'. Available agent(s): {availableAgentNames}");
     }
 
     private IEnumerable<string> AgentCompleter(CompletionContext context)

--- a/shell/ShellCopilot.Kernel/Command/CodeCommand.cs
+++ b/shell/ShellCopilot.Kernel/Command/CodeCommand.cs
@@ -109,7 +109,7 @@ internal sealed class CodeCommand : CommandBase
         }
         catch (Exception e)
         {
-            host.MarkupErrorLine(e.Message);
+            host.WriteErrorLine(e.Message);
         }
     }
 }

--- a/shell/ShellCopilot.Kernel/Command/DislikeCommand.cs
+++ b/shell/ShellCopilot.Kernel/Command/DislikeCommand.cs
@@ -21,7 +21,7 @@ internal sealed class DislikeCommand : CommandBase
 
         if (shell.LastAgent is null)
         {
-            host.MarkupErrorLine("No previous response available to rate on.");
+            host.WriteErrorLine("No previous response available to rate on.");
             return;
         }
 

--- a/shell/ShellCopilot.Kernel/Command/LikeCommand.cs
+++ b/shell/ShellCopilot.Kernel/Command/LikeCommand.cs
@@ -18,7 +18,7 @@ internal sealed class LikeCommand : CommandBase
 
         if (shell.LastAgent is null)
         {
-            host.MarkupErrorLine("No previous response available to rate on.");
+            host.WriteErrorLine("No previous response available to rate on.");
             return;
         }
 

--- a/shell/ShellCopilot.Kernel/Command/RetryCommand.cs
+++ b/shell/ShellCopilot.Kernel/Command/RetryCommand.cs
@@ -17,7 +17,7 @@ internal sealed class RetryCommand : CommandBase
 
         if (shell.LastQuery is null)
         {
-            shell.Host.MarkupErrorLine("No previous query available.");
+            shell.Host.WriteErrorLine("No previous query available.");
             return;
         }
 

--- a/shell/ShellCopilot.Kernel/Host.cs
+++ b/shell/ShellCopilot.Kernel/Host.cs
@@ -69,7 +69,15 @@ internal sealed class Host : IHost
     /// <inheritdoc/>
     public IHost WriteErrorLine(string value)
     {
-        Console.Error.WriteLine(value);
+        if (Console.IsErrorRedirected || string.IsNullOrEmpty(value))
+        {
+            Console.Error.WriteLine(value);
+        }
+        else
+        {
+            _stderrConsole.MarkupLine(Formatter.Error(value.EscapeMarkup()));
+        }
+
         return this;
     }
 
@@ -94,21 +102,6 @@ internal sealed class Host : IHost
         else
         {
             AnsiConsole.MarkupLine(value);
-        }
-
-        return this;
-    }
-
-    /// <inheritdoc/>
-    public IHost MarkupErrorLine(string value)
-    {
-        if (string.IsNullOrEmpty(value))
-        {
-            Console.Error.WriteLine();
-        }
-        else
-        {
-            _stderrConsole.MarkupLine(Formatter.Error(value.EscapeMarkup()));
         }
 
         return this;

--- a/shell/ShellCopilot.Kernel/Shell.cs
+++ b/shell/ShellCopilot.Kernel/Shell.cs
@@ -211,7 +211,7 @@ internal sealed class Shell : IShell
             }
             catch (Exception ex)
             {
-                Host.MarkupErrorLine($"Failed to load the agent '{name}': {ex.Message}\n");
+                Host.WriteErrorLine($"Failed to load the agent '{name}': {ex.Message}\n");
             }
         }
 
@@ -368,7 +368,7 @@ internal sealed class Shell : IShell
         string commandLine = input[1..].Trim();
         if (commandLine == string.Empty)
         {
-            Host.MarkupErrorLine("Command is missing.");
+            Host.WriteErrorLine("Command is missing.");
             return;
         }
 
@@ -378,7 +378,7 @@ internal sealed class Shell : IShell
         }
         catch (Exception e)
         {
-            Host.MarkupErrorLine(e.Message);
+            Host.WriteErrorLine(e.Message);
         }
     }
 
@@ -555,7 +555,7 @@ internal sealed class Shell : IShell
 
                             agent.OrchestratorRoleDisabled = true;
                             Host.WriteLine()
-                                .MarkupErrorLine($"Operation failed: {ex.Message}")
+                                .WriteErrorLine($"Operation failed: {ex.Message}")
                                 .WriteLine()
                                 .MarkupNoteLine($"The orchestrator role is disabled due to the failure. Continue with the active agent [green]{agent.Impl.Name}[/] for the query.");
                         }
@@ -588,13 +588,13 @@ internal sealed class Shell : IShell
                     }
 
                     Host.WriteErrorLine()
-                        .MarkupErrorLine($"Agent failed to generate a response: {ex.Message}")
+                        .WriteErrorLine($"Agent failed to generate a response: {ex.Message}")
                         .WriteErrorLine();
                 }
             }
             catch (ShellCopilotException e)
             {
-                Host.MarkupErrorLine(e.Message);
+                Host.WriteErrorLine(e.Message);
                 if (e.HandlerAction is ExceptionHandlerAction.Stop)
                 {
                     break;
@@ -611,8 +611,8 @@ internal sealed class Shell : IShell
     {
         if (ActiveAgent is null)
         {
-            Host.MarkupErrorLine("No active agent was configured.");
-            Host.MarkupErrorLine($"Run '{Utils.AppName} --settings' to configure the active agent. Run '{Utils.AppName} --help' for details.");
+            Host.WriteErrorLine("No active agent was configured.");
+            Host.WriteErrorLine($"Run '{Utils.AppName} --settings' to configure the active agent. Run '{Utils.AppName} --help' for details.");
 
             return;
         }
@@ -623,11 +623,11 @@ internal sealed class Shell : IShell
         }
         catch (OperationCanceledException)
         {
-            Host.MarkupErrorLine("Operation was aborted.");
+            Host.WriteErrorLine("Operation was aborted.");
         }
         catch (ShellCopilotException exception)
         {
-            Host.MarkupErrorLine(exception.Message);
+            Host.WriteErrorLine(exception.Message);
         }
     }
 }

--- a/shell/ShellCopilot.OpenAI.Agent/GPT.cs
+++ b/shell/ShellCopilot.OpenAI.Agent/GPT.cs
@@ -104,7 +104,7 @@ public class GPT
     /// <returns>A boolean value indicates whether the validation and setup was successful.</returns>
     private async Task AskForModel(IHost host, CancellationToken cancellationToken)
     {
-        host.MarkupErrorLine($"'{ModelName}' is not a supported OpenAI chat completion model.");
+        host.WriteErrorLine($"'{ModelName}' is not a supported OpenAI chat completion model.");
         ModelName = await host.PromptForSelectionAsync(
             title: "Choose from the list of [green]supported OpenAI models[/]:",
             choices: ModelInfo.SupportedModels(),

--- a/shell/ShellCopilot.OpenAI.Agent/Settings.cs
+++ b/shell/ShellCopilot.OpenAI.Agent/Settings.cs
@@ -50,7 +50,7 @@ internal class Settings
     {
         if (_gpts.Count is 0)
         {
-            host.MarkupErrorLine("No GPT instance is available to use. Please update the setting file to declare GPT instances and specify the active GPT to use.");
+            host.WriteErrorLine("No GPT instance is available to use. Please update the setting file to declare GPT instances and specify the active GPT to use.");
             return false;
         }
 

--- a/shell/ShellCopilot.OpenAI.Agent/ShellCopilot.OpenAI.Agent.csproj
+++ b/shell/ShellCopilot.OpenAI.Agent/ShellCopilot.OpenAI.Agent.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Azure.AI.OpenAI" Version="1.0.0-beta.6" />
     <PackageReference Include="Azure.Core" Version="1.34.0" />
     <PackageReference Include="SharpToken" Version="1.2.2" />
-    <PackageReference Include="ShellCopilot.Abstraction" Version="0.1.0-beta.4">
+    <PackageReference Include="ShellCopilot.Abstraction" Version="0.1.0-beta.5">
       <ExcludeAssets>contentFiles</ExcludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Remove `MarkupErrorLine` and move its logic to `WriteErrorLine`. Make sure the message passed to `WriteErrorLine` if well escaped when we need to write out the error in markup formatted way.

