### PR TITLE
Update the colors used for display in Like/Dislike commands

### DIFF
--- a/shell/ShellCopilot.Kernel/Command/DislikeCommand.cs
+++ b/shell/ShellCopilot.Kernel/Command/DislikeCommand.cs
@@ -3,7 +3,7 @@ using ShellCopilot.Abstraction;
 
 namespace ShellCopilot.Kernel.Commands;
 
-internal sealed class DislikeCommand : CommandBase
+internal sealed class DislikeCommand : FeedbackCommand
 {
     private readonly List<string> _choices;
 
@@ -27,29 +27,24 @@ internal sealed class DislikeCommand : CommandBase
 
         try
         {
-            host.MarkupLine("[cyan]Thanks for your feedback. Please share more about your experience.[/]\n");
+            host.WriteLine("Thanks for your feedback. Please share more about your experience.\n");
             string shortFeedback = host
-                .PromptForSelectionAsync("[cyan]Was the response:[/]", _choices, cancellationToken: shell.CancellationToken)
+                .PromptForSelectionAsync("Was the response:", _choices, cancellationToken: shell.CancellationToken)
                 .GetAwaiter()
                 .GetResult();
 
-            host.MarkupLine($"[cyan]The response was:[/] {shortFeedback}\n");
+            host.WriteLine($"The response was: {shortFeedback}\n");
             string longFeedback = host
-                .PromptForTextAsync("[cyan]What went wrong?[/] ", optional: true, shell.CancellationToken)
+                .PromptForTextAsync("What went wrong? ", optional: true, shell.CancellationToken)
                 .GetAwaiter()
                 .GetResult();
 
             host.WriteLine();
-            string prompt = $"[cyan]{LikeCommand.GetPromptForHistorySharing(shell.LastAgent.Impl)}[/]";
-
-            bool share = host
-                .PromptForConfirmationAsync(
-                    prompt: prompt,
-                    defaultValue: true,
-                    shell.CancellationToken)
+            string prompt = GetPromptForHistorySharing(shell.LastAgent.Impl);
+            bool share = AskForHistorySharingAsync(prompt, shell.CancellationToken)
                 .GetAwaiter().GetResult();
 
-            host.MarkupLine("[cyan]Thanks again for your feedback![/]");
+            host.WriteLine("\nThanks again for your feedback!\n");
             shell.OnUserAction(new DislikePayload(share, shortFeedback, longFeedback));
         }
         catch (OperationCanceledException)


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Update the colors used for display in Like/Dislike commands.
We use `cyan` color for display previously, and the feedback is to use plain colors.

Before:
![image](https://github.com/PowerShell/ShellCopilot/assets/127450/c73a946d-44c2-40aa-9343-2a9c18813ac8)

After:
![image](https://github.com/PowerShell/ShellCopilot/assets/127450/d7064c9e-f08b-40ad-8a61-01536e8b15ff)

