### PR TITLE
Update the colors used for Like and Dislike commands again

### DIFF
--- a/shell/ShellCopilot.Kernel/Command/DislikeCommand.cs
+++ b/shell/ShellCopilot.Kernel/Command/DislikeCommand.cs
@@ -33,7 +33,7 @@ internal sealed class DislikeCommand : FeedbackCommand
                 .GetAwaiter()
                 .GetResult();
 
-            host.WriteLine($"The response was: {shortFeedback}\n");
+            host.MarkupLine($"The response was: [teal]{shortFeedback}[/]\n");
             string longFeedback = host
                 .PromptForTextAsync("What went wrong? ", optional: true, shell.CancellationToken)
                 .GetAwaiter()
@@ -50,7 +50,7 @@ internal sealed class DislikeCommand : FeedbackCommand
         catch (OperationCanceledException)
         {
             // User pressed 'Ctrl+c', likely because they are just trying out the command.
-            host.WriteLine();
+            host.WriteLine("\n");
         }
     }
 }

--- a/shell/ShellCopilot.Kernel/Command/LikeCommand.cs
+++ b/shell/ShellCopilot.Kernel/Command/LikeCommand.cs
@@ -42,11 +42,10 @@ internal abstract class FeedbackCommand : CommandBase
     {
         var comparer = StringComparer.CurrentCultureIgnoreCase;
 
-        var prompt = new TextPrompt<char>($"{promptText} [[y/n]] [teal](y)[/]:", comparer)
+        var prompt = new TextPrompt<char>(promptText, comparer)
+            .PromptStyle(new Style(Color.Teal))
             .InvalidChoiceMessage("[red]Please select one of the available options[/]")
             .ValidationErrorMessage("[red]Please select one of the available options[/]")
-            .ShowChoices(false)
-            .ShowDefaultValue(false)
             .DefaultValue('y')
             .AddChoice('y')
             .AddChoice('n');
@@ -88,7 +87,7 @@ internal sealed class LikeCommand : FeedbackCommand
         catch (OperationCanceledException)
         {
             // User pressed 'Ctrl+c', likely because they are just trying out the command.
-            host.WriteLine();
+            host.WriteLine("\n");
         }
     }
 }

--- a/shell/ShellCopilot.Kernel/Host.cs
+++ b/shell/ShellCopilot.Kernel/Host.cs
@@ -452,7 +452,7 @@ internal sealed class Host : IHost
         IAnsiConsole ansiConsole = _outputRedirected ? _stderrConsole : AnsiConsole.Console;
         string promptToUse = optional ? $"[grey][[Optional]][/] {prompt}" : prompt;
         return await new TextPrompt<string>(promptToUse) { AllowEmpty = optional }
-            .PromptStyle(Style.Plain)
+            .PromptStyle(new Style(Color.Teal))
             .ShowAsync(ansiConsole, cancellationToken)
             .ConfigureAwait(false);
     }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Update the colors used for Like and Dislike commands again to differentiate between prompt message from user input.

![image](https://github.com/PowerShell/ShellCopilot/assets/127450/ebbd0347-ad41-4fe5-88a6-cf474c2419c4)
