### PR TITLE
Fix the status message to check against

### DIFF
--- a/shell/ShellCopilot.Azure.Agent/AzPS/AzPSChatService.cs
+++ b/shell/ShellCopilot.Azure.Agent/AzPS/AzPSChatService.cs
@@ -125,7 +125,7 @@ internal class AzPSChatService : IDisposable
             while ((line = await reader.ReadLineAsync(cancellationToken)) is not null)
             {
                 var chunk = JsonSerializer.Deserialize<ChunkData>(line, Utils.JsonOptions);
-                if (chunk.Status.Equals("Generating Answer", StringComparison.Ordinal))
+                if (chunk.Status.Equals("Starting Generate Answer", StringComparison.Ordinal))
                 {
                     // Received the first chunk for the real answer.
                     // Wrap it along with the reader and return the wrapper.


### PR DESCRIPTION
This fixes a regression introduced in #100. The status message checked against in that PR is incorrect. 