### PR TITLE
Refresh chat when switching to another agent. Also send the `refresh` user action to agent.

### DIFF
--- a/shell/ShellCopilot.Abstraction/ShellCopilot.Abstraction.csproj
+++ b/shell/ShellCopilot.Abstraction/ShellCopilot.Abstraction.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>ShellCopilot.Abstraction</AssemblyName>
 
     <PackageId>ShellCopilot.Abstraction</PackageId>
-    <Version>0.1.0-beta.8</Version>
+    <Version>0.1.0-beta.9</Version>
     <Company>Microsoft Corporation</Company>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>

--- a/shell/ShellCopilot.Abstraction/UserAction.cs
+++ b/shell/ShellCopilot.Abstraction/UserAction.cs
@@ -31,6 +31,11 @@ public enum UserAction
     /// User ran the 'retry' command.
     /// </summary>
     Retry,
+
+    /// <summary>
+    /// User ran the 'refresh' command.
+    /// </summary>
+    Refresh,
 }
 
 public abstract class UserActionPayload
@@ -92,4 +97,9 @@ public sealed class RetryPayload : UserActionPayload
         ArgumentException.ThrowIfNullOrEmpty(lastQuery);
         LastQuery = lastQuery;
     }
+}
+
+public sealed class RefreshPayload : UserActionPayload
+{
+    public RefreshPayload() : base(UserAction.Refresh) { }
 }

--- a/shell/ShellCopilot.Azure.Agent/ShellCopilot.Azure.Agent.csproj
+++ b/shell/ShellCopilot.Azure.Agent/ShellCopilot.Azure.Agent.csproj
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.10.4" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.18.0" />
-    <PackageReference Include="ShellCopilot.Abstraction" Version="0.1.0-beta.8">
+    <PackageReference Include="ShellCopilot.Abstraction" Version="0.1.0-beta.9">
       <ExcludeAssets>contentFiles</ExcludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/shell/ShellCopilot.Kernel/Command/AgentCommand.cs
+++ b/shell/ShellCopilot.Kernel/Command/AgentCommand.cs
@@ -39,8 +39,10 @@ internal sealed class AgentCommand : CommandBase
     private void UseAgentAction(string name)
     {
         var shell = (Shell)Shell;
+        var host = shell.Host;
+
         LLMAgent chosenAgent = string.IsNullOrEmpty(name)
-            ? shell.Host.PromptForSelectionAsync(
+            ? host.PromptForSelectionAsync(
                 title: "[orange1]Please select an [Blue]agent[/] to use[/]:",
                 choices: shell.Agents,
                 converter: AgentName).GetAwaiter().GetResult()
@@ -53,25 +55,26 @@ internal sealed class AgentCommand : CommandBase
         }
 
         shell.SwitchActiveAgent(chosenAgent);
-        shell.Host.MarkupLine($"Using the agent [green]{chosenAgent.Impl.Name}[/]:");
-        chosenAgent.Display(shell.Host);
+        host.MarkupLine($"Using the agent [green]{chosenAgent.Impl.Name}[/]:");
+        chosenAgent.Display(host);
     }
 
     private void PopAgentAction()
     {
         var shell = (Shell)Shell;
+        var host = shell.Host;
 
         try
         {
             shell.PopActiveAgent();
 
             var current = shell.ActiveAgent;
-            shell.Host.MarkupLine($"Using the agent [green]{current.Impl.Name}[/]:");
-            current.Display(shell.Host);
+            host.MarkupLine($"Using the agent [green]{current.Impl.Name}[/]:");
+            current.Display(host);
         }
         catch (Exception ex)
         {
-            shell.Host.WriteErrorLine(ex.Message);
+            host.WriteErrorLine(ex.Message);
         }
     }
 

--- a/shell/ShellCopilot.Kernel/Command/RefreshCommand.cs
+++ b/shell/ShellCopilot.Kernel/Command/RefreshCommand.cs
@@ -18,6 +18,7 @@ internal sealed class RefreshCommand : CommandBase
 
         var shell = (Shell)Shell;
         shell.ActiveAgent.Impl.RefreshChat();
+        shell.OnUserAction(new RefreshPayload());
         shell.ShowBanner();
         shell.ShowLandingPage();
     }

--- a/shell/ShellCopilot.Kernel/Shell.cs
+++ b/shell/ShellCopilot.Kernel/Shell.cs
@@ -292,6 +292,7 @@ internal sealed class Shell : IShell
         if (loadCommands)
         {
             ILLMAgent impl = agent.Impl;
+            impl.RefreshChat();
             CommandRunner.UnloadAgentCommands();
             CommandRunner.LoadCommands(impl.GetCommands(), impl.Name);
         }
@@ -330,6 +331,7 @@ internal sealed class Shell : IShell
             _activeAgentStack.Push(agent);
             if (current != agent)
             {
+                impl.RefreshChat();
                 CommandRunner.UnloadAgentCommands();
                 CommandRunner.LoadCommands(impl.GetCommands(), impl.Name);
             }
@@ -337,6 +339,7 @@ internal sealed class Shell : IShell
         else
         {
             _activeAgentStack.Push(agent);
+            impl.RefreshChat();
             CommandRunner.LoadCommands(impl.GetCommands(), impl.Name);
         }
     }

--- a/shell/ShellCopilot.OpenAI.Agent/ShellCopilot.OpenAI.Agent.csproj
+++ b/shell/ShellCopilot.OpenAI.Agent/ShellCopilot.OpenAI.Agent.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Azure.AI.OpenAI" Version="1.0.0-beta.6" />
     <PackageReference Include="Azure.Core" Version="1.34.0" />
     <PackageReference Include="SharpToken" Version="1.2.2" />
-    <PackageReference Include="ShellCopilot.Abstraction" Version="0.1.0-beta.8">
+    <PackageReference Include="ShellCopilot.Abstraction" Version="0.1.0-beta.9">
       <ExcludeAssets>contentFiles</ExcludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

1. Refresh chat when switching to another agent. So, the conversation with the new agent doesn't get mixed with outdated history context.
2. Send the `refresh` user action to agent for telemetry collection.
