### PR TITLE
Make AISH read its version from the assembly attribute

### DIFF
--- a/shell/ReadLine/PSReadLine.csproj
+++ b/shell/ReadLine/PSReadLine.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\shell.common.props" />
 
+  <!-- Ported form PSReadLine 2.3.1.0 -->
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <AssemblyName>ReadLine</AssemblyName>
     <NoWarn>$(NoWarn);CA1416</NoWarn>
-    <AssemblyVersion>2.3.1.0</AssemblyVersion>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
   </PropertyGroup>
 

--- a/shell/ShellCopilot.Abstraction/ShellCopilot.Abstraction.csproj
+++ b/shell/ShellCopilot.Abstraction/ShellCopilot.Abstraction.csproj
@@ -5,7 +5,6 @@
     <AssemblyName>ShellCopilot.Abstraction</AssemblyName>
 
     <PackageId>ShellCopilot.Abstraction</PackageId>
-    <Version>0.1.0-beta.10</Version>
     <Company>Microsoft Corporation</Company>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>

--- a/shell/ShellCopilot.Azure.Agent/ShellCopilot.Azure.Agent.csproj
+++ b/shell/ShellCopilot.Azure.Agent/ShellCopilot.Azure.Agent.csproj
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.11.2" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.18.0" />
-    <PackageReference Include="ShellCopilot.Abstraction" Version="0.1.0-beta.10">
+    <PackageReference Include="ShellCopilot.Abstraction" Version="0.1.0-alpha.10">
       <ExcludeAssets>contentFiles</ExcludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/shell/ShellCopilot.Integration/ShellCopilot.Integration.csproj
+++ b/shell/ShellCopilot.Integration/ShellCopilot.Integration.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ShellCopilot.Abstraction" Version="0.1.0-beta.10" />
+    <PackageReference Include="ShellCopilot.Abstraction" Version="0.1.0-alpha.10" />
     <PackageReference Include="System.Management.Automation" Version="7.4.0">
       <ExcludeAssets>contentFiles</ExcludeAssets>
       <PrivateAssets>All</PrivateAssets>

--- a/shell/ShellCopilot.Interpreter.Agent/ShellCopilot.Interpreter.Agent.csproj
+++ b/shell/ShellCopilot.Interpreter.Agent/ShellCopilot.Interpreter.Agent.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Azure.AI.OpenAI" Version="1.0.0-beta.13" />
     <PackageReference Include="Azure.Core" Version="1.37.0" />
     <PackageReference Include="SharpToken" Version="1.2.15" />
-    <PackageReference Include="ShellCopilot.Abstraction" Version="0.1.0-beta.10">
+    <PackageReference Include="ShellCopilot.Abstraction" Version="0.1.0-alpha.10">
       <ExcludeAssets>contentFiles</ExcludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/shell/ShellCopilot.Kernel/Shell.cs
+++ b/shell/ShellCopilot.Kernel/Shell.cs
@@ -10,6 +10,7 @@ internal sealed class Shell : IShell
 {
     private readonly bool _isInteractive;
     private readonly string _prompt;
+    private readonly string _version;
     private readonly List<LLMAgent> _agents;
     private readonly Stack<LLMAgent> _activeAgentStack;
     private readonly ShellWrapper _wrapper;
@@ -99,6 +100,7 @@ internal sealed class Shell : IShell
         _activeAgentStack = new Stack<LLMAgent>();
         _textToIgnore = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         _cancellationSource = new CancellationTokenSource();
+        _version = typeof(Shell).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
 
         Exit = false;
         Regenerate = false;
@@ -126,7 +128,7 @@ internal sealed class Shell : IShell
     internal void ShowBanner()
     {
         string banner = _wrapper?.Banner is null ? "Shell Copilot" : _wrapper.Banner;
-        string version = _wrapper?.Version is null ? "v0.1.0-preview.1" : _wrapper.Version;
+        string version = _wrapper?.Version is null ? _version : _wrapper.Version;
         Host.MarkupLine($"[bold]{banner.EscapeMarkup()}[/]")
             .MarkupLine($"[grey]{version.EscapeMarkup()}[/]")
             .WriteLine();

--- a/shell/ShellCopilot.OpenAI.Agent/ShellCopilot.OpenAI.Agent.csproj
+++ b/shell/ShellCopilot.OpenAI.Agent/ShellCopilot.OpenAI.Agent.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Azure.AI.OpenAI" Version="1.0.0-beta.6" />
     <PackageReference Include="Azure.Core" Version="1.34.0" />
     <PackageReference Include="SharpToken" Version="1.2.2" />
-    <PackageReference Include="ShellCopilot.Abstraction" Version="0.1.0-beta.10">
+    <PackageReference Include="ShellCopilot.Abstraction" Version="0.1.0-alpha.10">
       <ExcludeAssets>contentFiles</ExcludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/shell/shell.common.props
+++ b/shell/shell.common.props
@@ -8,11 +8,13 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>12.0</LangVersion>
+    <Version>0.1.0-alpha.10</Version>
 
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
     <NeutralLanguage>en-US</NeutralLanguage>
+    <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

## PR Summary

Fix #95

Make AISH read its version from the `AssemblyInformationalVersionAttribute` from the assembly, so that `aish.exe --version` gives the same version as the banner message of `aish.exe`.

![image](https://github.com/PowerShell/AISH/assets/127450/2ff991d7-36a7-4170-a3e8-b0473563e7bb)

