### PR TITLE
Improve the rendering of 'ListItemBlock' and add the '/render' command

### DIFF
--- a/shell/Markdown.VT/Render/Blocks/CodeBlockRenderer.cs
+++ b/shell/Markdown.VT/Render/Blocks/CodeBlockRenderer.cs
@@ -34,7 +34,10 @@ public class CodeBlockRenderer : VTObjectRenderer<CodeBlock>
     protected override void Write(VTRenderer renderer, CodeBlock obj)
     {
         renderer.WriteLine();
-        renderer.PushIndentAndUpdateWidth(VTRenderer.DefaultIndent);
+        renderer.PushIndentAndUpdateWidth(
+            obj.Column > 0
+                ? new string(' ', obj.Column)
+                : VTRenderer.DefaultIndent);
 
         string langId = null;
         ILanguage language = null;

--- a/shell/Markdown.VT/Render/Blocks/ListBlockRenderer.cs
+++ b/shell/Markdown.VT/Render/Blocks/ListBlockRenderer.cs
@@ -31,9 +31,16 @@ internal class ListBlockRenderer : VTObjectRenderer<ListBlock>
             index = value;
         }
 
-        foreach (ListItemBlock listItem in obj)
+        for (int i = 0; i < obj.Count; i++)
         {
+            var listItem = (ListItemBlock) obj[i];
             var prefix = obj.IsOrdered ? $"{index++}. " : Bullet;
+
+            if (i > 0)
+            {
+                // Separate list items with an empty line.
+                renderer.WriteLine();
+            }
 
             renderer.Write(prefix).WriteChildren(listItem);
         }

--- a/shell/Markdown.VT/Render/Blocks/ParagraphBlockRenderer.cs
+++ b/shell/Markdown.VT/Render/Blocks/ParagraphBlockRenderer.cs
@@ -14,10 +14,41 @@ internal class ParagraphBlockRenderer : VTObjectRenderer<ParagraphBlock>
     {
         if (obj.Parent is MarkdownDocument)
         {
+            // Write an empty line if it's a top-level paragraph.
             renderer.WriteLine();
+        }
+        else if (obj.Parent is ListItemBlock listItem)
+        {
+            // When the current paragraph is in the middle of a 'ListItemBlock'
+            // that contains multiple items, then we write an empty line if the
+            // previous item is not a paragraph, e.g. when the previous item is
+            // a 'CodeBlock'.
+            int i = 0;
+            for (; i < listItem.Count; i++)
+            {
+                if (listItem[i] == obj)
+                {
+                    break;
+                }
+            }
+
+            if (i > 0 && listItem[i - 1] is not ParagraphBlock)
+            {
+                renderer.WriteLine();
+            }
+        }
+
+        if (obj.Column > 0)
+        {
+            renderer.PushIndentAndUpdateWidth(new string(' ', obj.Column));
         }
 
         renderer.WriteLeafInline(obj);
         renderer.EnsureLine();
+
+        if (obj.Column > 0)
+        {
+            renderer.PopIndentAndUpdateWidth();
+        }
     }
 }

--- a/shell/Markdown.VT/Render/VTRenderer.cs
+++ b/shell/Markdown.VT/Render/VTRenderer.cs
@@ -38,6 +38,10 @@ public sealed class VTRenderer : TextRendererBase<VTRenderer>
         _indentWidth = new List<int>();
         EscapeSequences = new VT100EscapeSequences(optionInfo);
 
+        // For all the renderers, some write out an extra line at the beginning to separate from the already
+        // rendered components. However, none of them write out extra line at the end of the rendering, and
+        // we should keep it that way because that makes it more predictable when we need to change the layout
+        // of the rendering for any renderers.
         // Default block renderers
         ObjectRenderers.Add(new CodeBlockRenderer());
         ObjectRenderers.Add(new ListBlockRenderer());

--- a/shell/ShellCopilot.Kernel/Command/CommandRunner.cs
+++ b/shell/ShellCopilot.Kernel/Command/CommandRunner.cs
@@ -35,6 +35,7 @@ internal class CommandRunner
             new RefreshCommand(),
             new RetryCommand(),
             new HelpCommand(),
+            new RenderCommand(),
         };
 
         LoadCommands(buildin, Core);

--- a/shell/ShellCopilot.Kernel/Command/RenderCommand.cs
+++ b/shell/ShellCopilot.Kernel/Command/RenderCommand.cs
@@ -1,0 +1,34 @@
+﻿using System.Text;
+using System.CommandLine;
+using ShellCopilot.Abstraction;
+
+namespace ShellCopilot.Kernel.Commands;
+
+internal sealed class RenderCommand : CommandBase
+{
+    public RenderCommand()
+        : base("render", "Render a markdown file, for diagnosis purpose.")
+    {
+        var file = new Argument<FileInfo>("file", "The file path to save the code to.");
+        AddArgument(file);
+        this.SetHandler(SaveAction, file);
+    }
+
+    private void SaveAction(FileInfo file)
+    {
+        var host = Shell.Host;
+
+        try
+        {
+            using FileStream stream = file.OpenRead();
+            using StreamReader reader = new(stream, Encoding.Default);
+
+            string text = reader.ReadToEnd();
+            host.RenderFullResponse(text);
+        }
+        catch (Exception e)
+        {
+            host.WriteErrorLine(e.Message);
+        }
+    }
+}


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Improve the rendering of 'ListItemBlock' and add the '/render' command.
- List items are separated with a new line to make it more readable.
- Code block and paragraphs within a list item are made aligned with the list item and better separated.
- Add `/render <file>` to render a markdown file, which makes it easier to diagnose the rendering issues.

See the rendering of the same markdown text before and after this fix.
 
**Before the fix**

![image](https://github.com/PowerShell/AISH/assets/127450/2e5a5365-aed3-4a05-90eb-6722abe39622)

**After the fix**

![image](https://github.com/PowerShell/AISH/assets/127450/6c34321e-6897-4949-a977-9c08c6235b6d)
