### PR TITLE
Enable `Start-Aish` on macOS when running in iTerm2 terminal

### DIFF
--- a/shell/ShellCopilot.Integration/Commands/StartAishCommand.cs
+++ b/shell/ShellCopilot.Integration/Commands/StartAishCommand.cs
@@ -242,7 +242,7 @@ public class StartAishCommand : PSCmdlet
                 # Update the layout, which will change the panes to preferred size.
                 await current_tab.async_update_layout()
 
-                await splitpane.async_send_text(f'{app_path} --channel {channel}\n')
+                await split_pane.async_send_text(f'{app_path} --channel {channel}\n')
             else:
                 # You can view this message in the script console.
                 print("No current iTerm2 window. Make sure you are running in iTerm2.")


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Fix #147

Enable `Start-Aish` on macOS when running in iTerm2 terminal.
iTerm2 supports Python API to programmatically update the iTerm2 layout, and we use Python script to open up the sidecar pane and run AISH in it. The Python script opens up the sidecar pane with 0.4 ratio, same as what we do on Windows.