### PR TITLE
Naming Refactor (1) - Update code to use 'AIShell' instead of 'ShellCopilot' or 'Shell Copilot'

### DIFF
--- a/shell/ShellCopilot.Abstraction/AssemblyInfo.cs
+++ b/shell/ShellCopilot.Abstraction/AssemblyInfo.cs
@@ -4,4 +4,4 @@
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 
-[assembly: InternalsVisibleTo("ShellCopilot.Kernel")]
+[assembly: InternalsVisibleTo("AIShell.Kernel")]

--- a/shell/ShellCopilot.Abstraction/CommandBase.cs
+++ b/shell/ShellCopilot.Abstraction/CommandBase.cs
@@ -2,7 +2,7 @@
 using System.CommandLine.Parsing;
 using System.CommandLine;
 
-namespace ShellCopilot.Abstraction;
+namespace AIShell.Abstraction;
 
 public abstract class CommandBase : Command, IDisposable
 {
@@ -22,7 +22,7 @@ public abstract class CommandBase : Command, IDisposable
     private Parser _parser;
 
     /// <summary>
-    /// Gets the <see cref="IShell"/> implementation to interact with Shell Copilot.
+    /// Gets the <see cref="IShell"/> implementation to interact with AIShell.
     /// </summary>
     public IShell Shell { internal set; get; }
 

--- a/shell/ShellCopilot.Abstraction/IHost.cs
+++ b/shell/ShellCopilot.Abstraction/IHost.cs
@@ -1,4 +1,4 @@
-﻿namespace ShellCopilot.Abstraction;
+﻿namespace AIShell.Abstraction;
 
 public interface IHost
 {

--- a/shell/ShellCopilot.Abstraction/ILLMAgent.cs
+++ b/shell/ShellCopilot.Abstraction/ILLMAgent.cs
@@ -1,7 +1,7 @@
-namespace ShellCopilot.Abstraction;
+namespace AIShell.Abstraction;
 
 /// <summary>
-/// Contract class for an application to warp around Shell Copilot.
+/// Contract class for an application to warp around AIShell.
 /// </summary>
 public class ShellWrapper
 {
@@ -10,18 +10,18 @@ public class ShellWrapper
 
     /// <summary>
     /// Name of the application to run from command line, e.g. 'az copilot'. Required key.
-    /// It's used to setup the configuration folder of Shell Copilot.
+    /// It's used to setup the configuration folder of AIShell.
     /// </summary>
     public string Name { set; get; }
 
     /// <summary>
-    /// Banner text to be displayed at the startup of Shell Copilot. Required key.
+    /// Banner text to be displayed at the startup of AIShell. Required key.
     /// </summary>
     public string Banner { set; get; }
 
     /// <summary>
-    /// Version to be displayed at the startup of Shell Copilot. Optional key.
-    /// The version of Shell Copilot will be used if this key is not specified.
+    /// Version to be displayed at the startup of AIShell. Optional key.
+    /// The version of AIShell will be used if this key is not specified.
     /// </summary>
     public string Version
     {
@@ -31,7 +31,7 @@ public class ShellWrapper
     }
 
     /// <summary>
-    /// The description to be displayed at the startup of Shell Copilot. Optional key.
+    /// The description to be displayed at the startup of AIShell. Optional key.
     /// The default description of the chosen agent will be used if this key is not specified.
     /// </summary>
     public string Description
@@ -47,7 +47,7 @@ public class ShellWrapper
     public string Prompt { set; get; }
 
     /// <summary>
-    /// The default agent to use, which should be available along with Shell Copilot. Required key.
+    /// The default agent to use, which should be available along with AIShell. Required key.
     /// </summary>
     public string Agent { set; get; }
 
@@ -88,7 +88,7 @@ public class AgentConfig
     public RenderingStyle RenderingStyle { set; get; }
 
     /// <summary>
-    /// Sets and gets the context information for the agent that is passed into Shell Copilot.
+    /// Sets and gets the context information for the agent that is passed into AIShell.
     /// </summary>
     public Dictionary<string, string> Context { set; get; }
 }

--- a/shell/ShellCopilot.Abstraction/IRenderElement.cs
+++ b/shell/ShellCopilot.Abstraction/IRenderElement.cs
@@ -1,6 +1,6 @@
 ﻿using System.Reflection;
 
-namespace ShellCopilot.Abstraction;
+namespace AIShell.Abstraction;
 
 public interface IRenderElement<T>
 {

--- a/shell/ShellCopilot.Abstraction/IShell.cs
+++ b/shell/ShellCopilot.Abstraction/IShell.cs
@@ -1,9 +1,9 @@
-namespace ShellCopilot.Abstraction;
+namespace AIShell.Abstraction;
 
 public interface IShell
 {
     /// <summary>
-    /// The host of the shell copilot.
+    /// The host of the AIShell.
     /// </summary>
     IHost Host { get; }
 

--- a/shell/ShellCopilot.Abstraction/IStreamRender.cs
+++ b/shell/ShellCopilot.Abstraction/IStreamRender.cs
@@ -1,4 +1,4 @@
-namespace ShellCopilot.Abstraction;
+namespace AIShell.Abstraction;
 
 public record CodeBlock(string Code, string Language);
 

--- a/shell/ShellCopilot.Abstraction/NamedPipe.cs
+++ b/shell/ShellCopilot.Abstraction/NamedPipe.cs
@@ -2,7 +2,7 @@
 using System.IO.Pipes;
 using System.Text.Json;
 
-namespace ShellCopilot.Abstraction;
+namespace AIShell.Abstraction;
 
 /// <summary>
 /// Message types.

--- a/shell/ShellCopilot.Abstraction/ShellCopilot.Abstraction.csproj
+++ b/shell/ShellCopilot.Abstraction/ShellCopilot.Abstraction.csproj
@@ -2,13 +2,13 @@
   <Import Project="..\shell.common.props" />
 
   <PropertyGroup>
-    <AssemblyName>ShellCopilot.Abstraction</AssemblyName>
+    <AssemblyName>AIShell.Abstraction</AssemblyName>
 
-    <PackageId>ShellCopilot.Abstraction</PackageId>
+    <PackageId>AIShell.Abstraction</PackageId>
     <Company>Microsoft Corporation</Company>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    <Description>The abstraction layer SDK for building a plugin agent for Shell Copilot.</Description>
+    <Description>The abstraction layer SDK for building a plugin agent for AIShell.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>

--- a/shell/ShellCopilot.Abstraction/UserAction.cs
+++ b/shell/ShellCopilot.Abstraction/UserAction.cs
@@ -1,4 +1,4 @@
-﻿namespace ShellCopilot.Abstraction;
+﻿namespace AIShell.Abstraction;
 
 public enum UserAction
 {

--- a/shell/ShellCopilot.App/Program.cs
+++ b/shell/ShellCopilot.App/Program.cs
@@ -1,10 +1,10 @@
 ﻿using System.CommandLine;
 using System.Text;
 using System.Text.Json;
-using ShellCopilot.Abstraction;
-using ShellCopilot.Kernel;
+using AIShell.Abstraction;
+using AIShell.Kernel;
 
-namespace ShellCopilot.App;
+namespace AIShell.App;
 
 internal class Program
 {
@@ -26,7 +26,7 @@ internal class Program
         Console.OutputEncoding = Encoding.Default;
         Argument<string> query = new("query", getDefaultValue: () => null, "The query term used to get response from AI.");
         Option<string> channel = new("--channel", "A named pipe used to setup communication between aish and the command-line shell.");
-        Option<FileInfo> shellWrapper = new("--shell-wrapper", "Path to the configuration file to wrap Shell Copilot as a different application.");
+        Option<FileInfo> shellWrapper = new("--shell-wrapper", "Path to the configuration file to wrap AIShell as a different application.");
 
         query.AddValidator(result =>
         {

--- a/shell/ShellCopilot.Integration/Aish.psd1
+++ b/shell/ShellCopilot.Integration/Aish.psd1
@@ -1,15 +1,15 @@
 @{
     RootModule = 'Aish.psm1'
-    NestedModules = @("ShellCopilot.Integration.dll")
+    NestedModules = @("AIShell.Integration.dll")
     ModuleVersion = '0.1.0'
     GUID = 'ECB8BEE0-59B9-4DAE-9D7B-A990B480279A'
     Author = 'Microsoft Corporation'
     CompanyName = 'Microsoft Corporation'
     Copyright = '(c) Microsoft Corporation. All rights reserved.'
-    Description = 'Integration with the AISH to provide intelligent shell experience'
+    Description = 'Integration with the AIShell to provide intelligent shell experience'
     PowerShellVersion = '7.4'
     FunctionsToExport = @()
-    CmdletsToExport = @('Start-Aish','Invoke-Aish','Resolve-Error')
+    CmdletsToExport = @('Start-AIShell','Invoke-AIShell','Resolve-Error')
     VariablesToExport = '*'
     AliasesToExport = @('aish', 'askai', 'fixit')
 }

--- a/shell/ShellCopilot.Integration/Aish.psm1
+++ b/shell/ShellCopilot.Integration/Aish.psm1
@@ -1,3 +1,3 @@
 
 ## Create the channel singleton when loading the module.
-$null = [ShellCopilot.Integration.AishChannel]::CreateSingleton($host.Runspace, [Microsoft.PowerShell.PSConsoleReadLine])
+$null = [AIShell.Integration.Channel]::CreateSingleton($host.Runspace, [Microsoft.PowerShell.PSConsoleReadLine])

--- a/shell/ShellCopilot.Integration/AishFeedbackProvider.cs
+++ b/shell/ShellCopilot.Integration/AishFeedbackProvider.cs
@@ -2,17 +2,17 @@ using System.Management.Automation;
 using System.Management.Automation.Subsystem;
 using System.Management.Automation.Subsystem.Feedback;
 using System.Text;
-using ShellCopilot.Abstraction;
+using AIShell.Abstraction;
 
-namespace ShellCopilot.Integration;
+namespace AIShell.Integration;
 
-public sealed class AishErrorFeedback : IFeedbackProvider
+public sealed class ErrorFeedback : IFeedbackProvider
 {
     internal const string GUID = "10A13623-CE5E-4808-8346-1DEC831C24BB";
 
     private readonly Guid _guid;
 
-    internal AishErrorFeedback()
+    internal ErrorFeedback()
     {
         _guid = new Guid(GUID);
         SubsystemManager.RegisterSubsystem(SubsystemKind.FeedbackProvider, this);
@@ -22,16 +22,16 @@ public sealed class AishErrorFeedback : IFeedbackProvider
 
     public Guid Id => _guid;
 
-    public string Name => "aish";
+    public string Name => "AIShell";
 
-    public string Description => "Provide feedback for errors by leveraging AI agents running in aish.";
+    public string Description => "Provide feedback for errors by leveraging AI agents running in AIShell.";
 
     public FeedbackTrigger Trigger => FeedbackTrigger.Error;
 
     public FeedbackItem GetFeedback(FeedbackContext context, CancellationToken token)
     {
         // The trigger we listen to is 'Error', so 'LastError' won't be null.
-        AishChannel channel = AishChannel.Singleton;
+        Channel channel = Channel.Singleton;
         if (channel.CheckConnection(blocking: false, out _))
         {
             string query = CreateQueryForError(context.CommandLine, context.LastError, channel);
@@ -44,7 +44,7 @@ public sealed class AishErrorFeedback : IFeedbackProvider
         return null;
     }
 
-    internal static string CreateQueryForError(string commandLine, ErrorRecord lastError, AishChannel channel)
+    internal static string CreateQueryForError(string commandLine, ErrorRecord lastError, Channel channel)
     {
         Exception exception = lastError.Exception;
         StringBuilder sb = new StringBuilder(capacity: 100)

--- a/shell/ShellCopilot.Integration/AishPredictor.cs
+++ b/shell/ShellCopilot.Integration/AishPredictor.cs
@@ -1,9 +1,9 @@
 using System.Management.Automation.Subsystem;
 using System.Management.Automation.Subsystem.Prediction;
 
-namespace ShellCopilot.Integration;
+namespace AIShell.Integration;
 
-public sealed class AishPredictor : ICommandPredictor
+public sealed class Predictor : ICommandPredictor
 {
     private const int MaxRoundsToInvalidate = 10;
     private const string GUID = "F4CEBE0C-AB0C-4F9B-B24D-CB911EA6DB29";
@@ -14,7 +14,7 @@ public sealed class AishPredictor : ICommandPredictor
     private bool _checkExecutionResult;
     private List<PredictionCandidate> _candidates;
 
-    internal AishPredictor()
+    internal Predictor()
     {
         _guid = new Guid(GUID);
         _invalidationCount = -1;
@@ -27,9 +27,9 @@ public sealed class AishPredictor : ICommandPredictor
 
     public Guid Id => _guid;
 
-    public string Name => "aish";
+    public string Name => "AIShell";
 
-    public string Description => "Provide command-line prediction by leveraging AI agents running in aish.";
+    public string Description => "Provide command-line prediction by leveraging AI agents running in AIShell.";
 
     public bool CanAcceptFeedback(PredictionClient client, PredictorFeedbackKind feedback)
     {

--- a/shell/ShellCopilot.Integration/Commands/InvokeAishCommand.cs
+++ b/shell/ShellCopilot.Integration/Commands/InvokeAishCommand.cs
@@ -1,12 +1,12 @@
 using System.Collections.ObjectModel;
 using System.Management.Automation;
-using ShellCopilot.Abstraction;
+using AIShell.Abstraction;
 
-namespace ShellCopilot.Integration;
+namespace AIShell.Integration;
 
 [Alias("askai")]
-[Cmdlet(VerbsLifecycle.Invoke, "Aish", DefaultParameterSetName = "Default")]
-public class InvokeAishCommand : PSCmdlet
+[Cmdlet(VerbsLifecycle.Invoke, "AIShell", DefaultParameterSetName = "Default")]
+public class InvokeAIShellCommand : PSCmdlet
 {
     [Parameter(Position = 0, Mandatory = true)]
     public string Query { get; set; }
@@ -55,6 +55,6 @@ public class InvokeAishCommand : PSCmdlet
         }
 
         string context = results?.Count > 0 ? results[0] : null;
-        AishChannel.Singleton.PostQuery(new PostQueryMessage(Query, context, Agent));
+        Channel.Singleton.PostQuery(new PostQueryMessage(Query, context, Agent));
     }
 }

--- a/shell/ShellCopilot.Integration/Commands/ResolveErrorCommand.cs
+++ b/shell/ShellCopilot.Integration/Commands/ResolveErrorCommand.cs
@@ -1,9 +1,9 @@
 using System.Collections;
 using System.Management.Automation;
 using Microsoft.PowerShell.Commands;
-using ShellCopilot.Abstraction;
+using AIShell.Abstraction;
 
-namespace ShellCopilot.Integration;
+namespace AIShell.Integration;
 
 [Alias("fixit")]
 [Cmdlet(VerbsDiagnostic.Resolve, "Error")]
@@ -42,12 +42,12 @@ public class ResolveErrorCommand : PSCmdlet
 
         string query = null, context = null;
         HistoryInfo lastHistory = results[0];
-        AishChannel channel = AishChannel.Singleton;
+        Channel channel = Channel.Singleton;
         string commandLine = lastHistory.CommandLine;
 
         if (TryGetLastError(lastHistory, out ErrorRecord lastError))
         {
-            query = AishErrorFeedback.CreateQueryForError(commandLine, lastError, channel);
+            query = ErrorFeedback.CreateQueryForError(commandLine, lastError, channel);
         }
         else if (lastExitCode is 0)
         {

--- a/shell/ShellCopilot.Integration/Commands/StartAishCommand.cs
+++ b/shell/ShellCopilot.Integration/Commands/StartAishCommand.cs
@@ -2,11 +2,11 @@ using System.Diagnostics;
 using System.Management.Automation;
 using System.Text;
 
-namespace ShellCopilot.Integration;
+namespace AIShell.Integration;
 
 [Alias("aish")]
-[Cmdlet(VerbsLifecycle.Start, "Aish")]
-public class StartAishCommand : PSCmdlet
+[Cmdlet(VerbsLifecycle.Start, "AIShell")]
+public class StartAIShellCommand : PSCmdlet
 {
     [Parameter]
     [ValidateNotNullOrEmpty]
@@ -21,7 +21,7 @@ public class StartAishCommand : PSCmdlet
             {
                 ThrowTerminatingError(new(
                     new NotSupportedException("The executable 'aish' cannot be found."),
-                    "AISHMissing",
+                    "AIShellMissing",
                     ErrorCategory.NotInstalled,
                     targetObject: null));
             }
@@ -110,7 +110,7 @@ public class StartAishCommand : PSCmdlet
 
     protected override void EndProcessing()
     {
-        string pipeName = AishChannel.Singleton.StartChannelSetup();
+        string pipeName = Channel.Singleton.StartChannelSetup();
 
         if (OperatingSystem.IsWindows())
         {
@@ -132,7 +132,7 @@ public class StartAishCommand : PSCmdlet
                         "-s",
                         "0.4",
                         "--title",
-                        "AISH",
+                        "AIShell",
                         Path,
                         "--channel",
                         pipeName
@@ -155,7 +155,7 @@ public class StartAishCommand : PSCmdlet
                         "-s",
                         "0.4",
                         "--title",
-                        "AISH",
+                        "AIShell",
                         Path,
                         "--channel",
                         pipeName

--- a/shell/ShellCopilot.Integration/ShellCopilot.Integration.csproj
+++ b/shell/ShellCopilot.Integration/ShellCopilot.Integration.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <AssemblyName>AIShell.Integration</AssemblyName>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
@@ -17,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ShellCopilot.Abstraction" Version="0.1.0-alpha.11" />
+    <PackageReference Include="AIShell.Abstraction" Version="0.1.0-alpha.11" />
     <PackageReference Include="System.Management.Automation" Version="7.4.0">
       <ExcludeAssets>contentFiles</ExcludeAssets>
       <PrivateAssets>All</PrivateAssets>

--- a/shell/ShellCopilot.Interpreter.Agent/Agent.cs
+++ b/shell/ShellCopilot.Interpreter.Agent/Agent.cs
@@ -1,8 +1,8 @@
 using System.Text;
 using System.Text.Json;
-using ShellCopilot.Abstraction;
+using AIShell.Abstraction;
 
-namespace ShellCopilot.Interpreter.Agent;
+namespace AIShell.Interpreter.Agent;
 
 public sealed class InterpreterAgent : ILLMAgent
 {

--- a/shell/ShellCopilot.Interpreter.Agent/ExecutionService/CodeExecutionService.cs
+++ b/shell/ShellCopilot.Interpreter.Agent/ExecutionService/CodeExecutionService.cs
@@ -1,4 +1,4 @@
-﻿namespace ShellCopilot.Interpreter.Agent;
+﻿namespace AIShell.Interpreter.Agent;
 
 /// <summary>
 /// This class handles code exeuction on the local machine. All information 

--- a/shell/ShellCopilot.Interpreter.Agent/ExecutionService/Languages/PowerShell.cs
+++ b/shell/ShellCopilot.Interpreter.Agent/ExecutionService/Languages/PowerShell.cs
@@ -1,8 +1,8 @@
-﻿using ShellCopilot.Abstraction;
+﻿using AIShell.Abstraction;
 using System.ComponentModel;
 using System.Diagnostics;
 
-namespace ShellCopilot.Interpreter.Agent;
+namespace AIShell.Interpreter.Agent;
 
 /// <summary>
 /// This class is used to execute powershell code on the local machine. It inherits most functionality 

--- a/shell/ShellCopilot.Interpreter.Agent/ExecutionService/Languages/Python.cs
+++ b/shell/ShellCopilot.Interpreter.Agent/ExecutionService/Languages/Python.cs
@@ -1,4 +1,4 @@
-﻿namespace ShellCopilot.Interpreter.Agent;
+﻿namespace AIShell.Interpreter.Agent;
 
 /// <summary>
 /// This class is used to execute Python code on the local machine. It inherits most functionality 

--- a/shell/ShellCopilot.Interpreter.Agent/ExecutionService/Languages/SubprocessLanguage.cs
+++ b/shell/ShellCopilot.Interpreter.Agent/ExecutionService/Languages/SubprocessLanguage.cs
@@ -2,7 +2,7 @@
 using System.Text;
 using System.Runtime.InteropServices;
 
-namespace ShellCopilot.Interpreter.Agent;
+namespace AIShell.Interpreter.Agent;
 
 /// <summary>
 /// This is the parent class for all languages.
@@ -188,7 +188,7 @@ internal abstract class SubprocessLanguage : IDisposable
         {
             return;
         }
-        // Pressing CTRL+C in Shell Copilot during python code execution will propogate the command to 
+        // Pressing CTRL+C in AIShell during python code execution will propogate the command to 
         // the python process and cause a KeyboardInterrupt exception. The KeyboardInterrupt will stop 
         // code execution and print the exception to stderr. Then we will never encounter the end of exeuction
         // marker, "##end_of_execution##" so DoneExecutionEvent is set here instead.

--- a/shell/ShellCopilot.Interpreter.Agent/ExecutionService/OutputData.cs
+++ b/shell/ShellCopilot.Interpreter.Agent/ExecutionService/OutputData.cs
@@ -1,4 +1,4 @@
-namespace ShellCopilot.Interpreter.Agent;
+namespace AIShell.Interpreter.Agent;
 
 internal enum OutputType
 {

--- a/shell/ShellCopilot.Interpreter.Agent/Helpers.cs
+++ b/shell/ShellCopilot.Interpreter.Agent/Helpers.cs
@@ -7,7 +7,7 @@ using Azure;
 using Azure.Core;
 using Azure.Core.Pipeline;
 
-namespace ShellCopilot.Interpreter.Agent;
+namespace AIShell.Interpreter.Agent;
 
 /// <summary>
 /// Static type that contains all utility methods.

--- a/shell/ShellCopilot.Interpreter.Agent/Model/BaseModel.cs
+++ b/shell/ShellCopilot.Interpreter.Agent/Model/BaseModel.cs
@@ -1,8 +1,8 @@
 ﻿using Azure.AI.OpenAI;
 using Azure;
-using ShellCopilot.Abstraction;
+using AIShell.Abstraction;
 
-namespace ShellCopilot.Interpreter.Agent;
+namespace AIShell.Interpreter.Agent;
 
 /// <summary>
 /// The base model class for LLMs. Implementations are FunctionCallingModel and TextBasedModels.

--- a/shell/ShellCopilot.Interpreter.Agent/Model/FunctionCallingModel.cs
+++ b/shell/ShellCopilot.Interpreter.Agent/Model/FunctionCallingModel.cs
@@ -1,9 +1,9 @@
 ﻿using Azure.AI.OpenAI;
-using ShellCopilot.Abstraction;
+using AIShell.Abstraction;
 using System.Text;
 using System.Text.Json;
 
-namespace ShellCopilot.Interpreter.Agent;
+namespace AIShell.Interpreter.Agent;
 
 internal static class Tools
 {

--- a/shell/ShellCopilot.Interpreter.Agent/Model/TextBasedModel.cs
+++ b/shell/ShellCopilot.Interpreter.Agent/Model/TextBasedModel.cs
@@ -1,7 +1,7 @@
 ﻿using Azure.AI.OpenAI;
-using ShellCopilot.Abstraction;
+using AIShell.Abstraction;
 
-namespace ShellCopilot.Interpreter.Agent;
+namespace AIShell.Interpreter.Agent;
 
 internal class TextBasedModel : BaseModel
 {

--- a/shell/ShellCopilot.Interpreter.Agent/ModelInfo.cs
+++ b/shell/ShellCopilot.Interpreter.Agent/ModelInfo.cs
@@ -1,6 +1,6 @@
 using SharpToken;
 
-namespace ShellCopilot.Interpreter.Agent;
+namespace AIShell.Interpreter.Agent;
 
 internal class ModelInfo
 {

--- a/shell/ShellCopilot.Interpreter.Agent/Service.cs
+++ b/shell/ShellCopilot.Interpreter.Agent/Service.cs
@@ -5,7 +5,7 @@ using Azure.Core;
 using Azure.AI.OpenAI;
 using SharpToken;
 
-namespace ShellCopilot.Interpreter.Agent;
+namespace AIShell.Interpreter.Agent;
 
 internal class ChatService
 {

--- a/shell/ShellCopilot.Interpreter.Agent/Settings.cs
+++ b/shell/ShellCopilot.Interpreter.Agent/Settings.cs
@@ -2,9 +2,9 @@ using System.Diagnostics;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Security;
-using ShellCopilot.Abstraction;
+using AIShell.Abstraction;
 
-namespace ShellCopilot.Interpreter.Agent;
+namespace AIShell.Interpreter.Agent;
 
 internal enum EndpointType
 {

--- a/shell/ShellCopilot.Interpreter.Agent/ShellCopilot.Interpreter.Agent.csproj
+++ b/shell/ShellCopilot.Interpreter.Agent/ShellCopilot.Interpreter.Agent.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Azure.AI.OpenAI" Version="1.0.0-beta.13" />
     <PackageReference Include="Azure.Core" Version="1.37.0" />
     <PackageReference Include="SharpToken" Version="2.0.3" />
-    <PackageReference Include="ShellCopilot.Abstraction" Version="0.1.0-alpha.11">
+    <PackageReference Include="AIShell.Abstraction" Version="0.1.0-alpha.11">
       <ExcludeAssets>contentFiles</ExcludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/shell/ShellCopilot.Interpreter.Agent/TaskCompletionChat.cs
+++ b/shell/ShellCopilot.Interpreter.Agent/TaskCompletionChat.cs
@@ -1,7 +1,7 @@
 ﻿using System.Runtime;
-using ShellCopilot.Abstraction;
+using AIShell.Abstraction;
 
-namespace ShellCopilot.Interpreter.Agent;
+namespace AIShell.Interpreter.Agent;
 
 /// <summary>
 /// Manages a task chat session with automated user responses that guide the AI to complete the task.

--- a/shell/ShellCopilot.Interpreter.Agent/Utility/DataPacket.cs
+++ b/shell/ShellCopilot.Interpreter.Agent/Utility/DataPacket.cs
@@ -1,7 +1,6 @@
 ﻿using Azure.AI.OpenAI;
-using System;
 
-namespace ShellCopilot.Interpreter.Agent;
+namespace AIShell.Interpreter.Agent;
 
 /// <summary>
 /// This class is used to encapsulate data that is sent between Agent and CodeExeuctionService.

--- a/shell/ShellCopilot.Interpreter.Agent/Utility/TaskCompletionChatPrompts.cs
+++ b/shell/ShellCopilot.Interpreter.Agent/Utility/TaskCompletionChatPrompts.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿namespace AIShell.Interpreter.Agent;
 
 /// <summary>
 /// Summary description for Class1
@@ -23,5 +23,4 @@ public static class TaskCompletionChatPrompts
                        "If it is what you were expecting please move on to the next step and only the next step. If the task is done say " +
                        "EXACTLY 'The task is done.'\n Code output:\n\n"},
     };
-
 }

--- a/shell/ShellCopilot.Interpreter.Agent/Utility/ToolResponsePacket.cs
+++ b/shell/ShellCopilot.Interpreter.Agent/Utility/ToolResponsePacket.cs
@@ -1,7 +1,7 @@
 ﻿using Azure.AI.OpenAI;
-using System.Security.Cryptography;
 
-namespace ShellCopilot.Interpreter.Agent;
+namespace AIShell.Interpreter.Agent;
+
 /// <summary>
 /// Summarizes the content of a response from the tool into booleans.
 /// </summary>

--- a/shell/ShellCopilot.Kernel/Command/AgentCommand.cs
+++ b/shell/ShellCopilot.Kernel/Command/AgentCommand.cs
@@ -2,9 +2,9 @@
 using System.CommandLine.Completions;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
-using ShellCopilot.Abstraction;
+using AIShell.Abstraction;
 
-namespace ShellCopilot.Kernel.Commands;
+namespace AIShell.Kernel.Commands;
 
 internal sealed class AgentCommand : CommandBase
 {

--- a/shell/ShellCopilot.Kernel/Command/ClearCommand.cs
+++ b/shell/ShellCopilot.Kernel/Command/ClearCommand.cs
@@ -1,7 +1,7 @@
 ﻿using System.CommandLine;
-using ShellCopilot.Abstraction;
+using AIShell.Abstraction;
 
-namespace ShellCopilot.Kernel.Commands;
+namespace AIShell.Kernel.Commands;
 
 internal sealed class ClearCommand : CommandBase
 {

--- a/shell/ShellCopilot.Kernel/Command/CodeCommand.cs
+++ b/shell/ShellCopilot.Kernel/Command/CodeCommand.cs
@@ -1,8 +1,8 @@
 ﻿using System.Text;
 using System.CommandLine;
-using ShellCopilot.Abstraction;
+using AIShell.Abstraction;
 
-namespace ShellCopilot.Kernel.Commands;
+namespace AIShell.Kernel.Commands;
 
 internal sealed class CodeCommand : CommandBase
 {

--- a/shell/ShellCopilot.Kernel/Command/CommandRunner.cs
+++ b/shell/ShellCopilot.Kernel/Command/CommandRunner.cs
@@ -1,8 +1,8 @@
 ﻿using System.CommandLine;
 using System.CommandLine.Parsing;
-using ShellCopilot.Abstraction;
+using AIShell.Abstraction;
 
-namespace ShellCopilot.Kernel.Commands;
+namespace AIShell.Kernel.Commands;
 
 internal class CommandRunner
 {
@@ -99,14 +99,14 @@ internal class CommandRunner
     /// Invoke the given command line.
     /// </summary>
     /// <param name="commandLine">The command line to run, which may include flags and arguments.</param>
-    /// <exception cref="ShellCopilotException"></exception>
+    /// <exception cref="AIShellException"></exception>
     internal void InvokeCommand(string commandLine)
     {
         int index = commandLine.IndexOf(' ');
         string commandName = index is -1 ? commandLine : commandLine[..index];
 
         CommandBase command = ResolveCommand(commandName)
-            ?? throw new ShellCopilotException($"The term '{commandName}' is not recognized as a name of a command.");
+            ?? throw new AIShellException($"The term '{commandName}' is not recognized as a name of a command.");
 
         command.Parser.Invoke(commandLine);
     }

--- a/shell/ShellCopilot.Kernel/Command/DislikeCommand.cs
+++ b/shell/ShellCopilot.Kernel/Command/DislikeCommand.cs
@@ -1,7 +1,7 @@
 ﻿using System.CommandLine;
-using ShellCopilot.Abstraction;
+using AIShell.Abstraction;
 
-namespace ShellCopilot.Kernel.Commands;
+namespace AIShell.Kernel.Commands;
 
 internal sealed class DislikeCommand : FeedbackCommand
 {

--- a/shell/ShellCopilot.Kernel/Command/ExitCommand.cs
+++ b/shell/ShellCopilot.Kernel/Command/ExitCommand.cs
@@ -1,7 +1,7 @@
 ﻿using System.CommandLine;
-using ShellCopilot.Abstraction;
+using AIShell.Abstraction;
 
-namespace ShellCopilot.Kernel.Commands;
+namespace AIShell.Kernel.Commands;
 
 internal sealed class ExitCommand : CommandBase
 {

--- a/shell/ShellCopilot.Kernel/Command/HelpCommand.cs
+++ b/shell/ShellCopilot.Kernel/Command/HelpCommand.cs
@@ -1,7 +1,7 @@
 ﻿using System.CommandLine;
-using ShellCopilot.Abstraction;
+using AIShell.Abstraction;
 
-namespace ShellCopilot.Kernel.Commands;
+namespace AIShell.Kernel.Commands;
 
 internal sealed class HelpCommand : CommandBase
 {

--- a/shell/ShellCopilot.Kernel/Command/LikeCommand.cs
+++ b/shell/ShellCopilot.Kernel/Command/LikeCommand.cs
@@ -1,8 +1,8 @@
 ﻿using System.CommandLine;
-using ShellCopilot.Abstraction;
+using AIShell.Abstraction;
 using Spectre.Console;
 
-namespace ShellCopilot.Kernel.Commands;
+namespace AIShell.Kernel.Commands;
 
 internal abstract class FeedbackCommand : CommandBase
 {

--- a/shell/ShellCopilot.Kernel/Command/RefreshCommand.cs
+++ b/shell/ShellCopilot.Kernel/Command/RefreshCommand.cs
@@ -1,7 +1,7 @@
 ﻿using System.CommandLine;
-using ShellCopilot.Abstraction;
+using AIShell.Abstraction;
 
-namespace ShellCopilot.Kernel.Commands;
+namespace AIShell.Kernel.Commands;
 
 internal sealed class RefreshCommand : CommandBase
 {

--- a/shell/ShellCopilot.Kernel/Command/RenderCommand.cs
+++ b/shell/ShellCopilot.Kernel/Command/RenderCommand.cs
@@ -1,9 +1,9 @@
 ﻿using System.Text;
 using System.Text.Json;
 using System.CommandLine;
-using ShellCopilot.Abstraction;
+using AIShell.Abstraction;
 
-namespace ShellCopilot.Kernel.Commands;
+namespace AIShell.Kernel.Commands;
 
 internal sealed class RenderCommand : CommandBase
 {

--- a/shell/ShellCopilot.Kernel/Command/RetryCommand.cs
+++ b/shell/ShellCopilot.Kernel/Command/RetryCommand.cs
@@ -1,7 +1,7 @@
 ﻿using System.CommandLine;
-using ShellCopilot.Abstraction;
+using AIShell.Abstraction;
 
-namespace ShellCopilot.Kernel.Commands;
+namespace AIShell.Kernel.Commands;
 
 internal sealed class RetryCommand : CommandBase
 {

--- a/shell/ShellCopilot.Kernel/Exception.cs
+++ b/shell/ShellCopilot.Kernel/Exception.cs
@@ -1,4 +1,4 @@
-﻿namespace ShellCopilot.Kernel;
+﻿namespace AIShell.Kernel;
 
 public enum ExceptionHandlerAction
 {
@@ -6,21 +6,21 @@ public enum ExceptionHandlerAction
     Continue,
 }
 
-public sealed class ShellCopilotException : Exception
+public sealed class AIShellException : Exception
 {
     public ExceptionHandlerAction HandlerAction { get; }
 
-    public ShellCopilotException(string message)
+    public AIShellException(string message)
         : this(message, ExceptionHandlerAction.Continue, innerException: null)
     {
     }
 
-    public ShellCopilotException(string message, Exception innerException)
+    public AIShellException(string message, Exception innerException)
         : this(message, ExceptionHandlerAction.Continue, innerException)
     {
     }
 
-    public ShellCopilotException(string message, ExceptionHandlerAction action, Exception innerException = null)
+    public AIShellException(string message, ExceptionHandlerAction action, Exception innerException = null)
         : base(message, innerException)
     {
         ArgumentException.ThrowIfNullOrEmpty(message);

--- a/shell/ShellCopilot.Kernel/Host.cs
+++ b/shell/ShellCopilot.Kernel/Host.cs
@@ -1,13 +1,13 @@
 ﻿using System.Reflection;
 using System.Text;
 using Markdig.Helpers;
-using ShellCopilot.Abstraction;
+using AIShell.Abstraction;
 using Spectre.Console;
 
-namespace ShellCopilot.Kernel;
+namespace AIShell.Kernel;
 
 /// <summary>
-/// Host implementation of the Shell Copilot.
+/// Host implementation of the AIShell.
 /// </summary>
 internal sealed class Host : IHost
 {

--- a/shell/ShellCopilot.Kernel/LLMAgent.cs
+++ b/shell/ShellCopilot.Kernel/LLMAgent.cs
@@ -1,7 +1,7 @@
-﻿using ShellCopilot.Abstraction;
+﻿using AIShell.Abstraction;
 using Spectre.Console;
 
-namespace ShellCopilot.Kernel;
+namespace AIShell.Kernel;
 
 internal class LLMAgent
 {

--- a/shell/ShellCopilot.Kernel/Render/MarkdownRender.cs
+++ b/shell/ShellCopilot.Kernel/Render/MarkdownRender.cs
@@ -1,8 +1,8 @@
 ﻿using Markdig;
 using Markdown.VT;
-using ShellCopilot.Abstraction;
+using AIShell.Abstraction;
 
-namespace ShellCopilot.Kernel;
+namespace AIShell.Kernel;
 
 internal class CodeBlockVisitor : IVTRenderVisitor
 {

--- a/shell/ShellCopilot.Kernel/Render/PagingRender.cs
+++ b/shell/ShellCopilot.Kernel/Render/PagingRender.cs
@@ -4,7 +4,7 @@ using System.Text;
 
 using Spectre.Console;
 
-namespace ShellCopilot.Kernel;
+namespace AIShell.Kernel;
 
 internal class Pager
 {
@@ -88,7 +88,7 @@ internal class Pager
         }
         catch (Win32Exception e)
         {
-            throw new ShellCopilotException(
+            throw new AIShellException(
                 $"Failed to run the paging utility '{_command}': {e.Message}",
                 innerException: e);
         }

--- a/shell/ShellCopilot.Kernel/Render/StreamRender.cs
+++ b/shell/ShellCopilot.Kernel/Render/StreamRender.cs
@@ -1,10 +1,10 @@
 ﻿using System.Globalization;
 using System.Text;
 using System.Text.RegularExpressions;
-using ShellCopilot.Abstraction;
+using AIShell.Abstraction;
 using Spectre.Console;
 
-namespace ShellCopilot.Kernel;
+namespace AIShell.Kernel;
 
 internal sealed class DummyStreamRender : IStreamRender
 {

--- a/shell/ShellCopilot.Kernel/Setting.cs
+++ b/shell/ShellCopilot.Kernel/Setting.cs
@@ -1,10 +1,10 @@
 ﻿using System.Text.Json;
 using System.Text.Json.Serialization;
 
-namespace ShellCopilot.Kernel;
+namespace AIShell.Kernel;
 
 /// <summary>
-/// Settings for Shell Copilot.
+/// Settings for AIShell.
 /// </summary>
 internal class Setting
 {

--- a/shell/ShellCopilot.Kernel/Shell.cs
+++ b/shell/ShellCopilot.Kernel/Shell.cs
@@ -1,10 +1,10 @@
 using System.Reflection;
 using Microsoft.PowerShell;
-using ShellCopilot.Abstraction;
-using ShellCopilot.Kernel.Commands;
+using AIShell.Abstraction;
+using AIShell.Kernel.Commands;
 using Spectre.Console;
 
-namespace ShellCopilot.Kernel;
+namespace AIShell.Kernel;
 
 internal sealed class Shell : IShell
 {
@@ -127,7 +127,7 @@ internal sealed class Shell : IShell
 
     internal void ShowBanner()
     {
-        string banner = _wrapper?.Banner is null ? "Shell Copilot" : _wrapper.Banner;
+        string banner = _wrapper?.Banner is null ? "AI Shell" : _wrapper.Banner;
         string version = _wrapper?.Version is null ? _version : _wrapper.Version;
         Host.MarkupLine($"[bold]{banner.EscapeMarkup()}[/]")
             .MarkupLine($"[grey]{version.EscapeMarkup()}[/]")
@@ -688,7 +688,7 @@ internal sealed class Shell : IShell
                         .WriteErrorLine();
                 }
             }
-            catch (ShellCopilotException e)
+            catch (AIShellException e)
             {
                 Host.WriteErrorLine(e.Message);
                 if (e.HandlerAction is ExceptionHandlerAction.Stop)
@@ -721,7 +721,7 @@ internal sealed class Shell : IShell
         {
             Host.WriteErrorLine("Operation was aborted.");
         }
-        catch (ShellCopilotException exception)
+        catch (AIShellException exception)
         {
             Host.WriteErrorLine(exception.Message);
         }

--- a/shell/ShellCopilot.Kernel/ShellCopilot.Kernel.csproj
+++ b/shell/ShellCopilot.Kernel/ShellCopilot.Kernel.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\shell.common.props" />
 
   <PropertyGroup>
-    <AssemblyName>ShellCopilot.Kernel</AssemblyName>
+    <AssemblyName>AIShell.Kernel</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/shell/ShellCopilot.Kernel/ShellIntegration/Channel.cs
+++ b/shell/ShellCopilot.Kernel/ShellIntegration/Channel.cs
@@ -1,8 +1,8 @@
 ﻿using System.Diagnostics;
 using System.Text;
-using ShellCopilot.Abstraction;
+using AIShell.Abstraction;
 
-namespace ShellCopilot.Kernel;
+namespace AIShell.Kernel;
 
 internal class Channel : IDisposable
 {

--- a/shell/ShellCopilot.Kernel/ShellIntegration/ReadKeyProxy.cs
+++ b/shell/ShellCopilot.Kernel/ShellIntegration/ReadKeyProxy.cs
@@ -1,7 +1,7 @@
 ﻿using System.Reflection;
 using Microsoft.PowerShell;
 
-namespace ShellCopilot.Kernel;
+namespace AIShell.Kernel;
 
 /// <summary>
 /// When a channel is established between PowerShell and AISH, we need to be able to

--- a/shell/ShellCopilot.Kernel/Utility/Clipboard.cs
+++ b/shell/ShellCopilot.Kernel/Utility/Clipboard.cs
@@ -2,7 +2,7 @@
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 
-namespace ShellCopilot.Kernel;
+namespace AIShell.Kernel;
 
 internal static partial class Clipboard
 {

--- a/shell/ShellCopilot.Kernel/Utility/LoadContext.cs
+++ b/shell/ShellCopilot.Kernel/Utility/LoadContext.cs
@@ -1,7 +1,7 @@
 ﻿using System.Reflection;
 using System.Runtime.Loader;
 
-namespace ShellCopilot.Kernel;
+namespace AIShell.Kernel;
 
 internal class AgentAssemblyLoadContext : AssemblyLoadContext
 {

--- a/shell/ShellCopilot.Kernel/Utility/ReadLineHelper.cs
+++ b/shell/ShellCopilot.Kernel/Utility/ReadLineHelper.cs
@@ -4,10 +4,10 @@ using System.CommandLine.Parsing;
 using System.CommandLine.Completions;
 
 using Microsoft.PowerShell;
-using ShellCopilot.Abstraction;
-using ShellCopilot.Kernel.Commands;
+using AIShell.Abstraction;
+using AIShell.Kernel.Commands;
 
-namespace ShellCopilot.Kernel;
+namespace AIShell.Kernel;
 
 internal class ReadLineHelper : IReadLineHelper
 {

--- a/shell/ShellCopilot.Kernel/Utility/ShellArgs.cs
+++ b/shell/ShellCopilot.Kernel/Utility/ShellArgs.cs
@@ -1,6 +1,6 @@
-﻿using ShellCopilot.Abstraction;
+﻿using AIShell.Abstraction;
 
-namespace ShellCopilot.Kernel;
+namespace AIShell.Kernel;
 
 /// <summary>
 /// Arguments for the AI shell.

--- a/shell/ShellCopilot.Kernel/Utility/Utils.cs
+++ b/shell/ShellCopilot.Kernel/Utility/Utils.cs
@@ -6,9 +6,9 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.PowerShell;
-using ShellCopilot.Abstraction;
+using AIShell.Abstraction;
 
-namespace ShellCopilot.Kernel;
+namespace AIShell.Kernel;
 
 internal sealed class Disposable : IDisposable
 {

--- a/shell/ShellCopilot.Ollama.Agent/OllamaAgent.cs
+++ b/shell/ShellCopilot.Ollama.Agent/OllamaAgent.cs
@@ -1,9 +1,7 @@
 using System.Diagnostics;
-using System.Text;
-using System.Text.Json;
-using ShellCopilot.Abstraction;
+using AIShell.Abstraction;
 
-namespace ShellCopilot.Ollama.Agent;
+namespace AIShell.Ollama.Agent;
 
 public sealed class OllamaAgent : ILLMAgent
 {
@@ -40,11 +38,6 @@ public sealed class OllamaAgent : ILLMAgent
     private OllamaChatService _chatService;
 
     /// <summary>
-    /// A string builder to render the text at the end
-    /// </summary>
-    private StringBuilder _text;
-
-    /// <summary>
     /// Dispose method to clean up the unmanaged resource of the chatService
     /// </summary>
     public void Dispose()
@@ -58,7 +51,6 @@ public sealed class OllamaAgent : ILLMAgent
     /// <param name="config">Agent configuration for any configuration file and other settings</param>
     public void Initialize(AgentConfig config)
     {
-        _text = new StringBuilder();
         _chatService = new OllamaChatService();
 
         LegalLinks = new(StringComparer.OrdinalIgnoreCase)

--- a/shell/ShellCopilot.Ollama.Agent/OllamaChatService.cs
+++ b/shell/ShellCopilot.Ollama.Agent/OllamaChatService.cs
@@ -1,10 +1,9 @@
-﻿using System.Net.Http.Headers;
-using System.Text;
+﻿using System.Text;
 using System.Text.Json;
 
-using ShellCopilot.Abstraction;
+using AIShell.Abstraction;
 
-namespace ShellCopilot.Ollama.Agent;
+namespace AIShell.Ollama.Agent;
 
 internal class OllamaChatService : IDisposable
 {

--- a/shell/ShellCopilot.Ollama.Agent/OllamaSchema.cs
+++ b/shell/ShellCopilot.Ollama.Agent/OllamaSchema.cs
@@ -1,4 +1,4 @@
-namespace ShellCopilot.Ollama.Agent;
+namespace AIShell.Ollama.Agent;
 
 // Query class for the data to send to the endpoint
 internal class Query

--- a/shell/ShellCopilot.Ollama.Agent/ShellCopilot.Ollama.Agent.csproj
+++ b/shell/ShellCopilot.Ollama.Agent/ShellCopilot.Ollama.Agent.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ShellCopilot.Abstraction" Version="0.1.0-alpha.11">
+    <PackageReference Include="AIShell.Abstraction" Version="0.1.0-alpha.11">
       <ExcludeAssets>contentFiles</ExcludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/shell/ShellCopilot.OpenAI.Agent/Agent.cs
+++ b/shell/ShellCopilot.OpenAI.Agent/Agent.cs
@@ -1,9 +1,9 @@
 using System.Text;
 using System.Text.Json;
 using Azure.AI.OpenAI;
-using ShellCopilot.Abstraction;
+using AIShell.Abstraction;
 
-namespace ShellCopilot.OpenAI.Agent;
+namespace AIShell.OpenAI.Agent;
 
 public sealed class OpenAIAgent : ILLMAgent
 {

--- a/shell/ShellCopilot.OpenAI.Agent/Command.cs
+++ b/shell/ShellCopilot.OpenAI.Agent/Command.cs
@@ -1,8 +1,8 @@
 using System.CommandLine;
 using System.CommandLine.Completions;
-using ShellCopilot.Abstraction;
+using AIShell.Abstraction;
 
-namespace ShellCopilot.OpenAI.Agent;
+namespace AIShell.OpenAI.Agent;
 
 internal sealed class GPTCommand : CommandBase
 {

--- a/shell/ShellCopilot.OpenAI.Agent/GPT.cs
+++ b/shell/ShellCopilot.OpenAI.Agent/GPT.cs
@@ -1,9 +1,9 @@
 using System.Diagnostics;
 using System.Security;
 using System.Text.Json.Serialization;
-using ShellCopilot.Abstraction;
+using AIShell.Abstraction;
 
-namespace ShellCopilot.OpenAI.Agent;
+namespace AIShell.OpenAI.Agent;
 
 internal enum EndpointType
 {

--- a/shell/ShellCopilot.OpenAI.Agent/Helpers.cs
+++ b/shell/ShellCopilot.OpenAI.Agent/Helpers.cs
@@ -8,7 +8,7 @@ using Azure;
 using Azure.Core;
 using Azure.Core.Pipeline;
 
-namespace ShellCopilot.OpenAI.Agent;
+namespace AIShell.OpenAI.Agent;
 
 /// <summary>
 /// Static type that contains all utility methods.

--- a/shell/ShellCopilot.OpenAI.Agent/ModelInfo.cs
+++ b/shell/ShellCopilot.OpenAI.Agent/ModelInfo.cs
@@ -1,6 +1,6 @@
 using SharpToken;
 
-namespace ShellCopilot.OpenAI.Agent;
+namespace AIShell.OpenAI.Agent;
 
 internal class ModelInfo
 {

--- a/shell/ShellCopilot.OpenAI.Agent/Service.cs
+++ b/shell/ShellCopilot.OpenAI.Agent/Service.cs
@@ -4,7 +4,7 @@ using Azure.Core;
 using Azure.AI.OpenAI;
 using SharpToken;
 
-namespace ShellCopilot.OpenAI.Agent;
+namespace AIShell.OpenAI.Agent;
 
 internal class ChatService
 {

--- a/shell/ShellCopilot.OpenAI.Agent/Settings.cs
+++ b/shell/ShellCopilot.OpenAI.Agent/Settings.cs
@@ -1,8 +1,8 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using ShellCopilot.Abstraction;
+using AIShell.Abstraction;
 
-namespace ShellCopilot.OpenAI.Agent;
+namespace AIShell.OpenAI.Agent;
 
 internal class Settings
 {

--- a/shell/ShellCopilot.OpenAI.Agent/ShellCopilot.OpenAI.Agent.csproj
+++ b/shell/ShellCopilot.OpenAI.Agent/ShellCopilot.OpenAI.Agent.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Azure.AI.OpenAI" Version="1.0.0-beta.17" />
     <PackageReference Include="Azure.Core" Version="1.39.0" />
     <PackageReference Include="SharpToken" Version="2.0.3" />
-    <PackageReference Include="ShellCopilot.Abstraction" Version="0.1.0-alpha.11">
+    <PackageReference Include="AIShell.Abstraction" Version="0.1.0-alpha.11">
       <ExcludeAssets>contentFiles</ExcludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
### PR Summary

#118 Part 1

This is the 1st wave of the naming refactoring.
This PR updates code to use `AIShell` or `AI Shell` instead of `ShellCopilot` or `Shell Copilot`, but it doesn't change the file and directory names yet.

After this change, the core assemblies and package are with the prefix `AIShell`, such as `AIShell.Abstraction.dll` and `AIShell.Kernel.dll`, but the agent assemblies are still with the prefix `ShellCopilot.` and they will be changed after renaming the files and directories.
