### PR TITLE
Use 'python3' on non-Windows for the interpreter agent

### DIFF
--- a/shell/agents/AIShell.Interpreter.Agent/ExecutionService/Languages/Python.cs
+++ b/shell/agents/AIShell.Interpreter.Agent/ExecutionService/Languages/Python.cs
@@ -9,12 +9,14 @@ internal class Python: SubprocessLanguage
 {
     internal Python() : base()
     {
+        string python = OperatingSystem.IsWindows() ? "python" : "python3";
+
         // -q doesn't print the banner
         // -i runs the code in interactive mode
         // -u unbuffered binary stdout and stderr
         // Without these flags, the output is buffered and we can't read it until the process ends
-        StartCmd = ["python", "-qui"];
-        VersionCmd = ["python", "-V"];
+        StartCmd = [ python, "-qui" ];
+        VersionCmd = [ python, "-V" ];
     }
 
     protected override string PreprocessCode(string code)


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Fix #179

Use 'python3' on non-Windows for the interpreter agent.
