### PR TITLE
Use the DirectLine base URL returned from the 'start-conversation' API

### DIFF
--- a/shell/agents/Microsoft.Azure.Agent/Command.cs
+++ b/shell/agents/Microsoft.Azure.Agent/Command.cs
@@ -58,6 +58,10 @@ internal sealed class ReplaceCommand : CommandBase
             {
                 host.WriteErrorLine("No AI response available.");
             }
+            else if (cr.TopicName is CopilotActivity.CLIHandlerTopic)
+            {
+                host.WriteErrorLine("There is no placeholder left to replace.");
+            }
             else if (!cr.Text.Contains("```") && !cr.Text.Contains("~~~"))
             {
                 host.WriteErrorLine("The last AI response contains no code in it.");

--- a/shell/agents/Microsoft.Azure.Agent/Schema.cs
+++ b/shell/agents/Microsoft.Azure.Agent/Schema.cs
@@ -409,10 +409,9 @@ internal class UserAccessToken
 
 internal class UserDirectLineToken
 {
-    private const string REFRESH_TOKEN_URL = "https://directline.botframework.com/v3/directline/tokens/refresh";
-
     private string _token;
     private DateTimeOffset _expireOn;
+    private readonly string _tokenRenewUrl;
 
     /// <summary>
     /// The DirectLine token.
@@ -422,10 +421,11 @@ internal class UserDirectLineToken
     /// <summary>
     /// Initialize an instance.
     /// </summary>
-    internal UserDirectLineToken(string token, int expiresInSec)
+    internal UserDirectLineToken(string token, int expiresInSec, string dlBaseUrl)
     {
         _token = token;
         _expireOn = DateTimeOffset.UtcNow.AddSeconds(expiresInSec);
+        _tokenRenewUrl = $"{dlBaseUrl}/tokens/refresh";
     }
 
     /// <summary>
@@ -466,7 +466,7 @@ internal class UserDirectLineToken
 
         try
         {
-            HttpRequestMessage request = new(HttpMethod.Post, REFRESH_TOKEN_URL);
+            HttpRequestMessage request = new(HttpMethod.Post, _tokenRenewUrl);
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _token);
 
             var response = await httpClient.SendAsync(request, cancellationToken);


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

We got report that AI Shell cannot create a chat session in France with the following failure:
```
ERROR: Failed to open an conversation. HTTP status: Forbidden, Response: {
  "error": {
    "code": "RegionNotAllowed",
    "message": "The request received in france but target regional bot belongs to europe. Please check BaseURI
https://docs.microsoft.com/azure/bot-service/rest-api/bot-framework-rest-direct-line-3-0-api-reference?view=azure-bot-se
rvice-4.0#base-uri."
  }
}
```

It turns out we need to use different Direct Line base URL for different regions. To handle that, we should use the base URL returned from the 'start-conversation' API instead of hardcoding it.