### PR TITLE
Modifying readme and agent startup to point to docs on deploying AzOAI account

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ README in the each agent folder.
 
 To learn more about how to create an agent for yourself please see, [Creating an Agent][03].
 
+In order to use the `openai-gpt` agent you will need a valid Azure OpenAI service or a public OpenAI
+key. For more information on how to get an Azure OpenAI service, see
+[Deploying Azure OpenAI Service](./docs/development/AzureOAIDeployment/DeployingAzureOAI.md).
+
 ### Chat commands
 
 By default, `aish` provides a base set of chat `/` commands used to interact with the responses from

--- a/shell/agents/AIShell.OpenAI.Agent/Agent.cs
+++ b/shell/agents/AIShell.OpenAI.Agent/Agent.cs
@@ -151,6 +151,8 @@ public sealed class OpenAIAgent : ILLMAgent
             2. {1}. See details at
                  https://aka.ms/aish/openai
             3. Run '/refresh' to apply the new settings.
+
+            If you would like to learn more about deploying your own Azure OpenAI Service please see https://aka.ms/AIShell/DeployAOAI.
             """;
 
         if (_settings is null || _settings.GPTs.Count is 0)

--- a/shell/agents/AIShell.OpenAI.Agent/README.md
+++ b/shell/agents/AIShell.OpenAI.Agent/README.md
@@ -2,7 +2,7 @@
 
 This agent is designed to provide a flexible and user-friendly platform for interacting with OpenAI
 services, either the public OpenAI service or a private deployment of the Azure OpenAI service,
-through one or more customly defined GPT instances.
+through one or more custom defined GPT instances.
 
 For more information about this agent, see the [OpenAI Agent][01] documentation.
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Adding pointers on how to deploy an Azure OpenAI instance in the README and at start up for the openai-gpt agent.

<img width="1046" alt="Screenshot 2025-01-15 at 9 17 35 AM" src="https://github.com/user-attachments/assets/b1d1dc59-d81c-4df8-ab2a-c23f03506e51" />


## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
