### PR TITLE
Allow using 3rd party AI services that are compatible with OpenAI API format in the `openai-gpt` agent

### DIFF
--- a/shell/agents/AIShell.OpenAI.Agent/ModelInfo.cs
+++ b/shell/agents/AIShell.OpenAI.Agent/ModelInfo.cs
@@ -13,6 +13,11 @@ internal class ModelInfo
     private static readonly Dictionary<string, ModelInfo> s_modelMap;
     private static readonly Dictionary<string, Task<Tokenizer>> s_encodingMap;
 
+    // A rough estimate to cover all third-party models.
+    //  - most popular models today support 32K+ context length;
+    //  - use the gpt-4o encoding as an estimate for token count.
+    internal static readonly ModelInfo ThirdPartyModel = new(32_000, encoding: Gpt4oEncoding);
+
     static ModelInfo()
     {
         // For reference, see https://platform.openai.com/docs/models and the "Counting tokens" section in

--- a/shell/agents/AIShell.OpenAI.Agent/Service.cs
+++ b/shell/agents/AIShell.OpenAI.Agent/Service.cs
@@ -122,9 +122,10 @@ internal class ChatService
             return;
         }
 
+        EndpointType type = _gptToUse.Type;
         string userKey = Utils.ConvertFromSecureString(_gptToUse.Key);
 
-        if (_gptToUse.Type is EndpointType.AzureOpenAI)
+        if (type is EndpointType.AzureOpenAI)
         {
             // Create a client that targets Azure OpenAI service or Azure API Management service.
             var clientOptions = new AzureOpenAIClientOptions() { RetryPolicy = new ChatRetryPolicy() };
@@ -152,6 +153,11 @@ internal class ChatService
         {
             // Create a client that targets the non-Azure OpenAI service.
             var clientOptions = new OpenAIClientOptions() { RetryPolicy = new ChatRetryPolicy() };
+            if (type is EndpointType.CompatibleThirdParty)
+            {
+                clientOptions.Endpoint = new(_gptToUse.Endpoint);
+            }
+
             var aiClient = new OpenAIClient(new ApiKeyCredential(userKey), clientOptions);
             _client = aiClient.GetChatClient(_gptToUse.ModelName);
         }


### PR DESCRIPTION
# PR Summary

Add support for users to user an AI endpoint whose API is compatible with OpenAI API format.

1. **Azure OpenAI**
   It requires the `endpoint`, `deployment name`, and the `model name`.

2. **Public OpenAI**
   It requires the `model name`. No endpoint, no deployment name.

3. **OpenAI-compatible AI endpoint**
    It requires the `endpoint` and `model name`. No `deployment name`.

`CompatibleThirdParty` is added as a new `EndpointType` member.

Many LLM tools can setup local or remote API endpoint that is compatible with OpenAI API format for users to call a model hosted by the tool, such as [Ollama](https://ollama.com/blog/openai-compatibility), [LM Studio](https://lmstudio.ai/docs/api/openai-api), [LocalAI](https://localai.io/). The [DeepSeek v3](https://api-docs.deepseek.com/) and [Google Gemini](https://ai.google.dev/gemini-api/docs/openai) also provide OpenAI compatibility for their API endpoints.

To add an GPT targeting DeepSeek or Google Gemini, add the following to the `openai.agent.json` file:

```jsonc
{
    "GPTs": [
        {
          "Name": "gpt-deepseek",
          "Description": "A GPT instance using DeepSeek v3.",
          "Endpoint": "https://api.deepseek.com",
          "ModelName": "deepseek-chat",
          "Key": "your-deepseek-api-key",
          "SystemPrompt": "You are a helpful assistant."
        },

        {
          "Name": "gpt-gemini",
          "Description": "A GPT instance using Google Gemini.",
          "Endpoint": "https://generativelanguage.googleapis.com/v1beta/openai/",
          "ModelName": "gemini-1.5-flash",
          "Key": "your-gemini-api-key",
          "SystemPrompt": "You are a helpful assistant."
        }
    ]

    "Active": "gpt-deepseek"
}
```