### PR TITLE
Add the alias `shell` to the Bash parser

### DIFF
--- a/shell/Markdown.VT/ColorCode.VT/Parser/Bash.cs
+++ b/shell/Markdown.VT/ColorCode.VT/Parser/Bash.cs
@@ -65,7 +65,7 @@ public class Bash : ILanguage
         switch (lang.ToLower())
         {
             case "sh":
-                return true;
+            case "shell":
             case "azurecli":
                 return true;
             default:


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Add the alias `shell` to the Bash parser. The Azure Copilot started to return AzCLI code blocks enclosed with the `shell` block, which is not an alias for our Bash command parser and results in no syntax highlighting in the rendering for the code block:

![image](https://github.com/user-attachments/assets/a5940cb7-d6cd-455a-9c0a-344c84d013fb)

After the change, syntax highlighting kicks in as expected:

![image](https://github.com/user-attachments/assets/41af29ff-12d3-4e7a-85b2-d0b2dbd6bb21)
