### PR TITLE
Enable the `pluginstore` feature when talking to Azure Copilot and update the topic name for CLI handler

### DIFF
--- a/shell/agents/Microsoft.Azure.Agent/ChatSession.cs
+++ b/shell/agents/Microsoft.Azure.Agent/ChatSession.cs
@@ -56,9 +56,9 @@ internal class ChatSession : IDisposable
             ["getformstate"] = true,
             ["notificationcopilotbuttonallerror"] = false,
             ["chitchatprompt"] = true,
+            ["azurepluginstore"] = true,
             // TODO: the streaming is slow and not sending chunks, very clumsy for now.
             // ["streamresponse"] = true,
-            // ["azurepluginstore"] = true,
         };
     }
 
@@ -239,6 +239,11 @@ internal class ChatSession : IDisposable
                     content = new {
                         flights = _flights
                     }
+                },
+                new {
+                    contentType = Utils.JsonContentType,
+                    name = "azurecopilot/authorization",
+                    content = $"Bearer {_accessToken.Token}"
                 }
             },
         };

--- a/shell/agents/Microsoft.Azure.Agent/Schema.cs
+++ b/shell/agents/Microsoft.Azure.Agent/Schema.cs
@@ -120,7 +120,7 @@ internal class CopilotActivity
 {
     public const string ConversationStateName = "azurecopilot/conversationstate";
     public const string SuggestedResponseName = "azurecopilot/suggesteduserresponses";
-    public const string CLIHandlerTopic = "CLIHandler";
+    public const string CLIHandlerTopic = "generate_azure_cli_scripts";
 
     public string Type { get; set; }
     public string Id { get; set; }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

The required fixes to the `pluginstore` feature of Azure Copilot have been deployed, so we are enabling the `pluginstore` feature when talking to Azure Copilot and update the topic name for CLI handler (it uses `generate_azure_cli_scripts` as the topic name now).
