### PR TITLE
Enable parameter injection for Azure PowerShell response

### DIFF
--- a/shell/AIShell.App/AIShell.App.csproj
+++ b/shell/AIShell.App/AIShell.App.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <ProjectReference Include="..\AIShell.Kernel\AIShell.Kernel.csproj" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.7" />
   </ItemGroup>
 
 </Project>

--- a/shell/AIShell.Kernel/Utility/LoadContext.cs
+++ b/shell/AIShell.Kernel/Utility/LoadContext.cs
@@ -1,4 +1,6 @@
-﻿using System.Reflection;
+﻿using System.Collections.Concurrent;
+using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Runtime.Loader;
 
 namespace AIShell.Kernel;
@@ -6,6 +8,10 @@ namespace AIShell.Kernel;
 internal class AgentAssemblyLoadContext : AssemblyLoadContext
 {
     private readonly string _dependencyDir;
+    private readonly string _nativeLibExt;
+    private readonly List<string> _runtimeLibDir;
+    private readonly List<string> _runtimeNativeDir;
+    private readonly ConcurrentDictionary<string, Assembly> _cache;
 
     internal AgentAssemblyLoadContext(string name, string dependencyDir)
         : base($"{name.Replace(' ', '.')}-ALC", isCollectible: false)
@@ -17,20 +23,112 @@ internal class AgentAssemblyLoadContext : AssemblyLoadContext
 
         // Save the full path to the dependencies directory when creating the context.
         _dependencyDir = dependencyDir;
+        _runtimeLibDir = [];
+        _runtimeNativeDir = [];
+        _cache = [];
+
+        if (OperatingSystem.IsWindows())
+        {
+            _nativeLibExt = ".dll";
+            AddToList(_runtimeLibDir, Path.Combine(dependencyDir, "runtimes", "win", "lib"));
+            AddToList(_runtimeNativeDir, Path.Combine(dependencyDir, "runtimes", "win", "native"));
+        }
+        else if (OperatingSystem.IsLinux())
+        {
+            _nativeLibExt = ".so";
+            AddToList(_runtimeLibDir, Path.Combine(dependencyDir, "runtimes", "unix", "lib"));
+            AddToList(_runtimeLibDir, Path.Combine(dependencyDir, "runtimes", "linux", "lib"));
+
+            AddToList(_runtimeNativeDir, Path.Combine(dependencyDir, "runtimes", "unix", "native"));
+            AddToList(_runtimeNativeDir, Path.Combine(dependencyDir, "runtimes", "linux", "native"));
+        }
+        else if (OperatingSystem.IsMacOS())
+        {
+            _nativeLibExt = ".dylib";
+            AddToList(_runtimeLibDir, Path.Combine(dependencyDir, "runtimes", "unix", "lib"));
+            AddToList(_runtimeLibDir, Path.Combine(dependencyDir, "runtimes", "osx", "lib"));
+
+            AddToList(_runtimeNativeDir, Path.Combine(dependencyDir, "runtimes", "unix", "native"));
+            AddToList(_runtimeNativeDir, Path.Combine(dependencyDir, "runtimes", "osx", "native"));
+        }
+
+        AddToList(_runtimeLibDir, Path.Combine(dependencyDir, "runtimes", RuntimeInformation.RuntimeIdentifier, "lib"));
+        AddToList(_runtimeNativeDir, Path.Combine(dependencyDir, "runtimes", RuntimeInformation.RuntimeIdentifier, "native"));
+
+        ResolvingUnmanagedDll += ResolveUnmanagedDll;
     }
 
     protected override Assembly Load(AssemblyName assemblyName)
     {
-        // Create a path to the assembly in the dependencies directory.
-        string path = Path.Combine(_dependencyDir, $"{assemblyName.Name}.dll");
-
-        if (File.Exists(path))
+        if (_cache.TryGetValue(assemblyName.Name, out Assembly assembly))
         {
-            // If the assembly exists in our dependency directory, then load it into this load context.
-            return LoadFromAssemblyPath(path);
+            return assembly;
         }
 
-        // Otherwise we will depend on the default load context to resolve the request.
-        return null;
+        lock (this)
+        {
+            if (_cache.TryGetValue(assemblyName.Name, out assembly))
+            {
+                return assembly;
+            }
+
+            // Create a path to the assembly in the dependencies directory.
+            string assemblyFile = $"{assemblyName.Name}.dll";
+            string path = Path.Combine(_dependencyDir, assemblyFile);
+
+            if (File.Exists(path))
+            {
+                // If the assembly exists in our dependency directory, then load it into this load context.
+                assembly = LoadFromAssemblyPath(path);
+            }
+            else
+            {
+                foreach (string dir in _runtimeLibDir)
+                {
+                    IEnumerable<string> result = Directory.EnumerateFiles(dir, assemblyFile, SearchOption.AllDirectories);
+                    path = result.FirstOrDefault();
+
+                    if (path is not null)
+                    {
+                        assembly = LoadFromAssemblyPath(path);
+                        break;
+                    }
+                }
+            }
+
+            // Add the probing result to cache, regardless of whether we found it.
+            // If we didn't find it, we will add 'null' to the cache so that we don't probe
+            // again in case another loading request comes for the same assembly.
+            _cache.TryAdd(assemblyName.Name, assembly);
+
+            // Return the assembly if we found it, or return 'null' otherwise to depend on the default load context to resolve the request.
+            return assembly;
+        }
+    }
+
+    private nint ResolveUnmanagedDll(Assembly assembly, string libraryName)
+    {
+        string libraryFile = $"{libraryName}{_nativeLibExt}";
+
+        foreach (string dir in _runtimeNativeDir)
+        {
+            IEnumerable<string> result = Directory.EnumerateFiles(dir, libraryFile, SearchOption.AllDirectories);
+            string path = result.FirstOrDefault();
+
+            if (path is not null)
+            {
+                return NativeLibrary.Load(path);
+            }
+        }
+
+        return nint.Zero;
+    }
+
+    private static void AddToList(List<string> depList, string dirPath)
+    {
+        if (Directory.Exists(dirPath))
+        {
+            depList.Add(dirPath);
+        }
     }
 }

--- a/shell/agents/Microsoft.Azure.Agent/Command.cs
+++ b/shell/agents/Microsoft.Azure.Agent/Command.cs
@@ -33,9 +33,19 @@ internal sealed class ReplaceCommand : CommandBase
         const string vtReset = "\x1b[0m";
 
         StringBuilder cStr = new(capacity: command.Length + parameter.Length + placeholder.Length + 50);
-        cStr.Append(vtItalic)
-            .Append(vtCommand).Append("az").Append(vtFgDefault).Append(command.AsSpan(2)).Append(' ')
-            .Append(vtParameter).Append(parameter).Append(vtFgDefault).Append(' ')
+        cStr.Append(vtItalic);
+
+        int index = command.IndexOf(' ');
+        if (index is -1)
+        {
+            cStr.Append(vtCommand).Append(command).Append(vtFgDefault).Append(' ');
+        }
+        else
+        {
+            cStr.Append(vtCommand).Append(command.AsSpan(0, index)).Append(vtFgDefault).Append(command.AsSpan(index)).Append(' ');
+        }
+
+        cStr.Append(vtParameter).Append(parameter).Append(vtFgDefault).Append(' ')
             .Append(vtVariable).Append(placeholder).Append(vtFgDefault)
             .Append(vtReset);
 
@@ -125,15 +135,9 @@ internal sealed class ReplaceCommand : CommandBase
 
                 // Prompt for argument without printing captions again.
                 string value = host.PromptForArgument(argInfo, printCaption: false);
+                value = value?.Trim();
                 if (!string.IsNullOrEmpty(value))
                 {
-                    // Add quotes for the value if needed.
-                    value = value.Trim();
-                    if (value.StartsWith('-') || value.Contains(' ') || value.Contains('|'))
-                    {
-                        value = $"\"{value}\"";
-                    }
-
                     _values.Add(item.Name, value);
                     _agent.SaveUserValue(item.Name, value);
 

--- a/shell/agents/Microsoft.Azure.Agent/Microsoft.Azure.Agent.csproj
+++ b/shell/agents/Microsoft.Azure.Agent/Microsoft.Azure.Agent.csproj
@@ -20,6 +20,10 @@
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
     <PackageReference Include="Serilog.Sinks.Async" Version="2.0.0" />
+    <PackageReference Include="System.Management.Automation" Version="7.4.7">
+      <ExcludeAssets>contentFiles</ExcludeAssets>
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/shell/agents/Microsoft.Azure.Agent/Schema.cs
+++ b/shell/agents/Microsoft.Azure.Agent/Schema.cs
@@ -121,6 +121,7 @@ internal class CopilotActivity
     public const string ConversationStateName = "azurecopilot/conversationstate";
     public const string SuggestedResponseName = "azurecopilot/suggesteduserresponses";
     public const string CLIHandlerTopic = "generate_azure_cli_scripts";
+    public const string PSHandlerTopic = "generate_powershell_script";
 
     public string Type { get; set; }
     public string Id { get; set; }
@@ -297,6 +298,7 @@ internal class ResponseData
 {
     internal string Text { get; set; }
     internal string Locale { get; set; }
+    internal string TopicName { get; set; }
     internal List<CommandItem> CommandSet { get; set; }
     internal List<PlaceholderItem> PlaceholderSet { get; set; }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

## PR Summary

This PR enables parameter injection for responses from the Azure PowerShell handler.

- Supporting parameter injection for Azure PowerShell response requires to have PowerShell runtime available. However, pulling PowerShell dependencies at the agent level doesn't work because an agent gets loaded to its own `AssemblyLoadContext`, while PowerShell runtime has to live in the default `AssemblyLoadContext`. The solution is to make `AIShell` depend on PowerShell SDK so that the PowerShell dependencies are moved to the application level and are loaded into the default `AssemblyLoadContext`. With that, any agent can use PowerShell without needing to pull PowerShell dependency assemblies into the agent's folder.
- Updated the build script to properly deploy the PowerShell modules. They need to be placed in the same folder where `System.Management.Automation.dll` is located, AKA `$PSHOME`.
- Updated `AgentAssemblyLoadContext` to make it able to load assemblies and native libs from the `runtimes` folder under the agent folder.
- Updated the instruction prompt a bit to ask a placeholder to always be enclosed in double quotes. This is because today we want the placeholder to be represented in the `<xxx>` form, but the character `>` is a special operator in PowerShell and hence causing parsing issue.
- Introduced a PowerShell pool implementation, which is simple and tiny. The pool is created and populated with `PowerShell` instances (3 by default) in the background as early as the `DataRetriever` type gets initialized, so that when we need a `PowerShell` instance to perform parameter injection work for a AzPS command, it's likely one will be already available.
- Method `PairPlaceholdersForPSCode` is for looking for the command and parameter for a given placeholder for AzPS script. Sometimes the AzPS script first assigns all placeholder values to variables and then use those variables as arguments in commands. The method handles that case too.
- Method `GetArgValuesForAzPS` is for retrieving argument values for the given command and parameter. It depends on argument completion support in Azure PowerShell.

### Pending issue

I ran into an issue with the completer attribute `LocationCompleterAttribute` in Azure PowerShell:
- The `LocationCompleterAttribute` used for many `-Location` parameters always time out because it takes ~10 seconds for the first call to get back results.

The issue has been reported to @wyunchi-ms, who is working on improving its performance and hopefully will have it fixed in the next Az PowerShell release.

### Follow-up tasks

- Add unit tests for methods in `DataRetriever` and other types to cover the scenarios we support.
- Add logging and maybe telemetry based on feedback.
- What if the user doesn't have the necessary Az module installed? Today I assume all needed Az modules are available, but we should handle the case when any are not, in an intuitive way.

Tracked by https://github.com/PowerShell/AIShell/issues/342