### PR TITLE
Add support for Entra ID authentication when using interpreter or openai-gpt

### DIFF
--- a/shell/agents/AIShell.Interpreter.Agent/AIShell.Interpreter.Agent.csproj
+++ b/shell/agents/AIShell.Interpreter.Agent/AIShell.Interpreter.Agent.csproj
@@ -17,7 +17,8 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.AI.OpenAI" Version="1.0.0-beta.13" />
-    <PackageReference Include="Azure.Core" Version="1.37.0" />
+    <PackageReference Include="Azure.Identity" Version="1.13.2" />
+    <PackageReference Include="Azure.Core" Version="1.44.1" />
     <PackageReference Include="SharpToken" Version="2.0.3" />
   </ItemGroup>
 

--- a/shell/agents/AIShell.Interpreter.Agent/Agent.cs
+++ b/shell/agents/AIShell.Interpreter.Agent/Agent.cs
@@ -236,7 +236,7 @@ public sealed class InterpreterAgent : ILLMAgent
 
     private void NewExampleSettingFile()
     {
-        string SampleContent = """
+        string sample = $$"""
         {
           // To use the Azure OpenAI service:
           // - Set `Endpoint` to the endpoint of your Azure OpenAI service,
@@ -249,22 +249,37 @@ public sealed class InterpreterAgent : ILLMAgent
           "Deployment": "",
           "ModelName": "",
           "Key": "",
+          "AuthType": "ApiKey",
           "AutoExecution": false, // 'true' to allow the agent run code automatically; 'false' to always prompt before running code.
           "DisplayErrors": true   // 'true' to display the errors when running code; 'false' to hide the errors to be less verbose.
+
+          // To use Azure OpenAI service with Entra ID authentication:
+          // - Set `Endpoint` to the endpoint of your Azure OpenAI service.
+          // - Set `Deployment` to the deployment name of your Azure OpenAI service.
+          // - Set `ModelName` to the name of the model used for your deployment.
+          // - Set `AuthType` to "EntraID" to use Azure AD credentials.
+          /*
+          "Endpoint": "<insert your Azure OpenAI endpoint>",
+          "Deployment": "<insert your deployment name>",
+          "ModelName": "<insert the model name>",
+          "AuthType": "EntraID",
+          "AutoExecution": false,
+          "DisplayErrors": true
+          */
 
           // To use the public OpenAI service:
           // - Ignore the `Endpoint` and `Deployment` keys.
           // - Set `ModelName` to the name of the model to be used. e.g. "gpt-4o".
           // - Set `Key` to be the OpenAI access token.
-          // Replace the above with the following:
           /*
-          "ModelName": "",
-          "Key": "",
+          "ModelName": "<insert the model name>",
+          "Key": "<insert your key>",
+          "AuthType": "ApiKey",
           "AutoExecution": false,
           "DisplayErrors": true
           */
         }
         """;
-        File.WriteAllText(SettingFile, SampleContent, Encoding.UTF8);
+        File.WriteAllText(SettingFile, sample);
     }
 }

--- a/shell/agents/AIShell.Interpreter.Agent/Settings.cs
+++ b/shell/agents/AIShell.Interpreter.Agent/Settings.cs
@@ -75,7 +75,7 @@ internal class Settings
     /// <returns></returns>
     internal async Task<bool> SelfCheck(IHost host, CancellationToken token)
     {
-        if ((AuthType == AuthType.ApiKey && Key is not null || AuthType == AuthType.EntraID) && ModelInfo is not null)
+        if ((AuthType is AuthType.EntraID || Key is not null) && ModelInfo is not null)
         {
             return true;
         }

--- a/shell/agents/AIShell.Interpreter.Agent/Settings.cs
+++ b/shell/agents/AIShell.Interpreter.Agent/Settings.cs
@@ -12,6 +12,12 @@ internal enum EndpointType
     OpenAI,
 }
 
+public enum AuthType
+{
+    ApiKey,
+    EntraID
+}
+
 internal class Settings
 {
     internal EndpointType Type { get; }
@@ -22,6 +28,8 @@ internal class Settings
     public string Deployment { set; get; }
     public string ModelName { set; get; }
     public SecureString Key { set; get; }
+
+    public AuthType AuthType { set; get; } = AuthType.ApiKey;
 
     public bool AutoExecution { set; get; }
     public bool DisplayErrors { set; get; }
@@ -36,6 +44,7 @@ internal class Settings
         AutoExecution = configData.AutoExecution ?? false;
         DisplayErrors = configData.DisplayErrors ?? true;
         Key = configData.Key;
+        AuthType = configData.AuthType;
 
         Dirty = false;
         ModelInfo = ModelInfo.TryResolve(ModelName, out var model) ? model : null;
@@ -76,7 +85,7 @@ internal class Settings
                 await AskForModel(host, token);
             }
 
-            if (Key is null)
+            if (AuthType == AuthType.ApiKey && Key is null)
             {
                 await AskForKeyAsync(host, token);
             }
@@ -156,6 +165,7 @@ internal class Settings
             ModelName = this.ModelName,
             AutoExecution = this.AutoExecution,
             DisplayErrors = this.DisplayErrors,
+            AuthType = this.AuthType,
             Key = this.Key,
         };
     }
@@ -166,6 +176,7 @@ internal class ConfigData
     public string Endpoint { set; get; }
     public string Deployment { set; get; }
     public string ModelName { set; get; }
+    public AuthType AuthType { set; get; } = AuthType.ApiKey;
     public bool? AutoExecution { set; get; }
     public bool? DisplayErrors { set; get; }
 

--- a/shell/agents/AIShell.OpenAI.Agent/AIShell.OpenAI.Agent.csproj
+++ b/shell/agents/AIShell.OpenAI.Agent/AIShell.OpenAI.Agent.csproj
@@ -22,6 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.AI.OpenAI" Version="2.1.0" />
+    <PackageReference Include="Azure.Identity" Version="1.13.2" />
     <PackageReference Include="Microsoft.ML.Tokenizers" Version="1.0.1" />
     <PackageReference Include="Microsoft.ML.Tokenizers.Data.O200kBase" Version="1.0.1" />
     <PackageReference Include="Microsoft.ML.Tokenizers.Data.Cl100kBase" Version="1.0.1" />

--- a/shell/agents/AIShell.OpenAI.Agent/Agent.cs
+++ b/shell/agents/AIShell.OpenAI.Agent/Agent.cs
@@ -323,7 +323,7 @@ public sealed class OpenAIAgent : ILLMAgent
                 "Deployment": "<insert your deployment name>",
                 "ModelName": "gpt-4o",
                 "AuthType": "EntraID",
-                "SystemPrompt": "1. You are a helpful and friendly assistant with expertise in PowerShell scripting and command line."
+                "SystemPrompt": "You are a helpful and friendly assistant with expertise in PowerShell scripting and command line."
               }
               */
           ],

--- a/shell/agents/AIShell.OpenAI.Agent/Agent.cs
+++ b/shell/agents/AIShell.OpenAI.Agent/Agent.cs
@@ -84,7 +84,7 @@ public sealed class OpenAIAgent : ILLMAgent
     public bool CanAcceptFeedback(UserAction action) => false;
 
     /// <inheritdoc/>
-    public void OnUserAction(UserActionPayload actionPayload) {}
+    public void OnUserAction(UserActionPayload actionPayload) { }
 
     /// <inheritdoc/>
     public Task RefreshChatAsync(IShell shell, bool force)
@@ -308,6 +308,22 @@ public sealed class OpenAIAgent : ILLMAgent
                 "ModelName": "gpt-4o",
                 "Key": "<insert your key>",
                 "SystemPrompt": "1. You are a helpful and friendly assistant with expertise in PowerShell scripting and command line.\n2. Assume user is using the operating system `Windows 11` unless otherwise specified.\n3. Use the `code block` syntax in markdown to encapsulate any part in responses that is code, YAML, JSON or XML, but not table.\n4. When encapsulating command line code, use '```powershell' if it's PowerShell command; use '```sh' if it's non-PowerShell CLI command.\n5. When generating CLI commands, never ever break a command into multiple lines. Instead, always list all parameters and arguments of the command on the same line.\n6. Please keep the response concise but to the point. Do not overexplain."
+              },
+
+              // To use Azure OpenAI service with Entra ID authentication:
+              // - Set `Endpoint` to the endpoint of your Azure OpenAI service.
+              // - Set `Deployment` to the deployment name of your Azure OpenAI service.
+              // - Set `ModelName` to the name of the model used for your deployment, e.g. "gpt-4o".
+              // - Set `AuthType` to "EntraID" to use Azure AD credentials.
+              // For example:
+              {
+                "Name": "ps-az-entraId",
+                "Description": "A GPT instance with expertise in PowerShell scripting using Entra ID authentication.",
+                "Endpoint": "<insert your Azure OpenAI endpoint>",
+                "Deployment": "<insert your deployment name>",
+                "ModelName": "gpt-4o",
+                "AuthType": "EntraID",
+                "SystemPrompt": "1. You are a helpful and friendly assistant with expertise in PowerShell scripting and command line."
               }
               */
           ],

--- a/shell/agents/AIShell.OpenAI.Agent/GPT.cs
+++ b/shell/agents/AIShell.OpenAI.Agent/GPT.cs
@@ -92,7 +92,7 @@ public class GPT
     /// <returns></returns>
     internal async Task<bool> SelfCheck(IHost host, CancellationToken token)
     {
-        if ((AuthType == AuthType.ApiKey && Key is not null || AuthType == AuthType.EntraID) && ModelInfo is not null)
+        if ((AuthType is AuthType.EntraID || Key is not null) && ModelInfo is not null)
         {
             return true;
         }

--- a/shell/agents/AIShell.OpenAI.Agent/GPT.cs
+++ b/shell/agents/AIShell.OpenAI.Agent/GPT.cs
@@ -108,7 +108,7 @@ public class GPT
                 await AskForModel(host, token);
             }
 
-            if (AuthType == AuthType.ApiKey && Key is null)
+            if (AuthType is AuthType.ApiKey && Key is null)
             {
                 await AskForKeyAsync(host, token);
             }

--- a/shell/agents/AIShell.OpenAI.Agent/GPT.cs
+++ b/shell/agents/AIShell.OpenAI.Agent/GPT.cs
@@ -12,6 +12,12 @@ internal enum EndpointType
     CompatibleThirdParty,
 }
 
+public enum AuthType
+{
+    ApiKey,
+    EntraID
+}
+
 public class GPT
 {
     internal EndpointType Type { get; }
@@ -26,6 +32,10 @@ public class GPT
 
     [JsonConverter(typeof(SecureStringJsonConverter))]
     public SecureString Key { set; get; }
+
+    [JsonConverter(typeof(JsonStringEnumConverter<AuthType>))]
+    public AuthType AuthType { set; get; } = AuthType.ApiKey;
+
     public string SystemPrompt { set; get; }
 
     public GPT(
@@ -75,7 +85,7 @@ public class GPT
     /// <returns></returns>
     internal async Task<bool> SelfCheck(IHost host, CancellationToken token)
     {
-        if (Key is not null && ModelInfo is not null)
+        if ((AuthType == AuthType.EntraID || Key is not null) && ModelInfo is not null)
         {
             return true;
         }
@@ -91,7 +101,7 @@ public class GPT
                 await AskForModel(host, token);
             }
 
-            if (Key is null)
+            if (AuthType == AuthType.ApiKey && Key is null)
             {
                 await AskForKeyAsync(host, token);
             }

--- a/shell/agents/AIShell.OpenAI.Agent/Service.cs
+++ b/shell/agents/AIShell.OpenAI.Agent/Service.cs
@@ -1,6 +1,8 @@
 using System.ClientModel;
 using System.ClientModel.Primitives;
 using Azure.AI.OpenAI;
+using Azure.Core;
+using Azure.Identity;
 using Microsoft.ML.Tokenizers;
 using OpenAI;
 using OpenAI.Chat;
@@ -33,8 +35,8 @@ internal class ChatService
 
         _chatOptions = new ChatCompletionOptions()
         {
-           Temperature = 0,
-           MaxOutputTokenCount = MaxResponseToken,
+            Temperature = 0,
+            MaxOutputTokenCount = MaxResponseToken,
         };
     }
 
@@ -116,14 +118,14 @@ internal class ChatService
             && string.Equals(old.Endpoint, _gptToUse.Endpoint)
             && string.Equals(old.Deployment, _gptToUse.Deployment)
             && string.Equals(old.ModelName, _gptToUse.ModelName)
-            && old.Key.IsEqualTo(_gptToUse.Key))
+            && old.AuthType == _gptToUse.AuthType
+            && (old.AuthType == AuthType.EntraID || old.Key.IsEqualTo(_gptToUse.Key)))
         {
-            // It's the same same endpoint, so we reuse the existing client.
+            // It's the same endpoint and auth type, so we reuse the existing client.
             return;
         }
 
         EndpointType type = _gptToUse.Type;
-        string userKey = Utils.ConvertFromSecureString(_gptToUse.Key);
 
         if (type is EndpointType.AzureOpenAI)
         {
@@ -131,23 +133,39 @@ internal class ChatService
             var clientOptions = new AzureOpenAIClientOptions() { RetryPolicy = new ChatRetryPolicy() };
             bool isApimEndpoint = _gptToUse.Endpoint.EndsWith(Utils.ApimGatewayDomain);
 
-            if (isApimEndpoint)
+            if (_gptToUse.AuthType == AuthType.ApiKey)
             {
-                clientOptions.AddPolicy(
-                    ApiKeyAuthenticationPolicy.CreateHeaderApiKeyPolicy(
-                        new ApiKeyCredential(userKey),
-                        Utils.ApimAuthorizationHeader),
-                    PipelinePosition.PerTry);
+                string userKey = Utils.ConvertFromSecureString(_gptToUse.Key);
+
+                if (isApimEndpoint)
+                {
+                    clientOptions.AddPolicy(
+                        ApiKeyAuthenticationPolicy.CreateHeaderApiKeyPolicy(
+                            new ApiKeyCredential(userKey),
+                            Utils.ApimAuthorizationHeader),
+                        PipelinePosition.PerTry);
+                }
+
+                string azOpenAIApiKey = isApimEndpoint ? "placeholder-api-key" : userKey;
+
+                var aiClient = new AzureOpenAIClient(
+                    new Uri(_gptToUse.Endpoint),
+                    new ApiKeyCredential(azOpenAIApiKey),
+                    clientOptions);
+
+                _client = aiClient.GetChatClient(_gptToUse.Deployment);
             }
+            else if (_gptToUse.AuthType == AuthType.EntraID)
+            {
+                var credential = new DefaultAzureCredential();
 
-            string azOpenAIApiKey = isApimEndpoint ? "placeholder-api-key" : userKey;
+                var aiClient = new AzureOpenAIClient(
+                    new Uri(_gptToUse.Endpoint),
+                    credential,
+                    clientOptions);
 
-            var aiClient = new AzureOpenAIClient(
-                new Uri(_gptToUse.Endpoint),
-                new ApiKeyCredential(azOpenAIApiKey),
-                clientOptions);
-
-            _client = aiClient.GetChatClient(_gptToUse.Deployment);
+                _client = aiClient.GetChatClient(_gptToUse.Deployment);
+            }
         }
         else
         {
@@ -158,6 +176,7 @@ internal class ChatService
                 clientOptions.Endpoint = new(_gptToUse.Endpoint);
             }
 
+            string userKey = Utils.ConvertFromSecureString(_gptToUse.Key);
             var aiClient = new OpenAIClient(new ApiKeyCredential(userKey), clientOptions);
             _client = aiClient.GetChatClient(_gptToUse.ModelName);
         }

--- a/shell/agents/AIShell.OpenAI.Agent/Service.cs
+++ b/shell/agents/AIShell.OpenAI.Agent/Service.cs
@@ -119,7 +119,7 @@ internal class ChatService
             && string.Equals(old.Deployment, _gptToUse.Deployment)
             && string.Equals(old.ModelName, _gptToUse.ModelName)
             && old.AuthType == _gptToUse.AuthType
-            && (old.AuthType == AuthType.EntraID || old.Key.IsEqualTo(_gptToUse.Key)))
+            && (old.AuthType is AuthType.EntraID || old.Key.IsEqualTo(_gptToUse.Key)))
         {
             // It's the same endpoint and auth type, so we reuse the existing client.
             return;
@@ -133,7 +133,7 @@ internal class ChatService
             var clientOptions = new AzureOpenAIClientOptions() { RetryPolicy = new ChatRetryPolicy() };
             bool isApimEndpoint = _gptToUse.Endpoint.EndsWith(Utils.ApimGatewayDomain);
 
-            if (_gptToUse.AuthType == AuthType.ApiKey)
+            if (_gptToUse.AuthType is AuthType.ApiKey)
             {
                 string userKey = Utils.ConvertFromSecureString(_gptToUse.Key);
 
@@ -155,7 +155,7 @@ internal class ChatService
 
                 _client = aiClient.GetChatClient(_gptToUse.Deployment);
             }
-            else if (_gptToUse.AuthType == AuthType.EntraID)
+            else
             {
                 var credential = new DefaultAzureCredential();
 

--- a/shell/agents/AIShell.OpenAI.Agent/Settings.cs
+++ b/shell/agents/AIShell.OpenAI.Agent/Settings.cs
@@ -125,7 +125,7 @@ internal class Settings
                 new PropertyElement<GPT>(nameof(GPT.Name)),
                 new CustomElement<GPT>(label: "Active", m => m.Name == Active?.Name ? "true" : string.Empty),
                 new PropertyElement<GPT>(nameof(GPT.Description)),
-                            ]);
+            ]);
     }
 
     internal void ShowOneGPT(IHost host, string name)

--- a/shell/agents/AIShell.OpenAI.Agent/Settings.cs
+++ b/shell/agents/AIShell.OpenAI.Agent/Settings.cs
@@ -125,7 +125,7 @@ internal class Settings
                 new PropertyElement<GPT>(nameof(GPT.Name)),
                 new CustomElement<GPT>(label: "Active", m => m.Name == Active?.Name ? "true" : string.Empty),
                 new PropertyElement<GPT>(nameof(GPT.Description)),
-            ]);
+                            ]);
     }
 
     internal void ShowOneGPT(IHost host, string name)
@@ -139,6 +139,7 @@ internal class Settings
                 new PropertyElement<GPT>(nameof(GPT.Endpoint)),
                 new PropertyElement<GPT>(nameof(GPT.Deployment)),
                 new PropertyElement<GPT>(nameof(GPT.ModelName)),
+                new PropertyElement<GPT>(nameof(GPT.AuthType)),
                 new PropertyElement<GPT>(nameof(GPT.SystemPrompt)),
             ]);
     }


### PR DESCRIPTION
# PR Summary

Adds support for Entra ID authentication by specifying AuthType: "EntraID". This enables users to use "AuthType": "EntraID" instead of specifying an API key

## PR Context

Many organizations have a blanket ban on API keys, so this allows people in such situations to use AIShell.