### PR TITLE
Update the regex for matching single-quote and double-quote strings for PowerShell and Bash

### DIFF
--- a/shell/Markdown.VT/ColorCode.VT/Parser/Bash.cs
+++ b/shell/Markdown.VT/ColorCode.VT/Parser/Bash.cs
@@ -24,6 +24,20 @@ public class Bash : ILanguage
                     {1, BashCommentScope}
                 }),
 
+            new LanguageRule(
+                @"'[^\n]*?'",
+                new Dictionary<int, string>
+                {
+                    {0, ScopeName.String}
+                }),
+
+            new LanguageRule(
+                @"""[^\n]*?(?<!\\)""",
+                new Dictionary<int, string>
+                {
+                    {0, ScopeName.String}
+                }),
+
             // match the first word of a line in a multi-line string as the command name.
             new LanguageRule(
                 @"(?m)^\s*(\w+)",

--- a/shell/Markdown.VT/ColorCode.VT/Parser/PowerShell.cs
+++ b/shell/Markdown.VT/ColorCode.VT/Parser/PowerShell.cs
@@ -48,7 +48,7 @@ public class PowerShell : ILanguage
                             }),
 
                     new LanguageRule(
-                        @"'[^\n]*?(?<!\\)'",
+                        @"'[^\n]*?'",
                         new Dictionary<int, string>
                             {
                                 {0, ScopeName.String}
@@ -62,7 +62,7 @@ public class PowerShell : ILanguage
                             }),
 
                     new LanguageRule(
-                        @"(?s)(""[^\n]*?(?<!`)"")",
+                        @"""[^\n]*?(?<!`)""",
                         new Dictionary<int, string>
                             {
                                 {0, ScopeName.String}


### PR DESCRIPTION
### PR Summary

1. Fix the single-quote string regex for PowerShell -- backslash `\` is allowed at any position in a single-quoted string
2. Simplify the regex for double-quoted string regex for PowerShell -- the single-line mode `(?s)` has no effect because `.` is not used.
3. Add single-quote string and double-quote string regexes to Bash.