### PR TITLE
Support posting code from the sidecar AIShell to PowerShell with `Invoke-AIShell -PostCode`

### DIFF
--- a/shell/AIShell.Integration/AIShell.psd1
+++ b/shell/AIShell.Integration/AIShell.psd1
@@ -1,7 +1,7 @@
 @{
     RootModule = 'AIShell.psm1'
     NestedModules = @("AIShell.Integration.dll")
-    ModuleVersion = '1.0.3'
+    ModuleVersion = '1.0.4'
     GUID = 'ECB8BEE0-59B9-4DAE-9D7B-A990B480279A'
     Author = 'Microsoft Corporation'
     CompanyName = 'Microsoft Corporation'
@@ -13,5 +13,5 @@
     VariablesToExport = '*'
     AliasesToExport = @('aish', 'askai', 'fixit')
     HelpInfoURI = 'https://aka.ms/aishell-help'
-    PrivateData = @{ PSData = @{ Prerelease = 'preview3'; ProjectUri = 'https://github.com/PowerShell/AIShell' } }
+    PrivateData = @{ PSData = @{ Prerelease = 'preview4'; ProjectUri = 'https://github.com/PowerShell/AIShell' } }
 }

--- a/shell/AIShell.Integration/AIShell.psm1
+++ b/shell/AIShell.Integration/AIShell.psm1
@@ -1,3 +1,7 @@
+$module = Get-Module -Name PSReadLine
+if ($null -eq $module -or $module.Version -lt [version]"2.4.1") {
+    throw "The PSReadLine v2.4.1-beta1 or higher is required for the AIShell module to work properly."
+}
 
 ## Create the channel singleton when loading the module.
 $null = [AIShell.Integration.Channel]::CreateSingleton($host.Runspace, [Microsoft.PowerShell.PSConsoleReadLine])


### PR DESCRIPTION
### PR Summary

By leveraging the fix in https://github.com/PowerShell/PSReadLine/pull/4442, which handles buffer changes made by a handler of the `OnIdle` event, now we are able to post code to PowerShell from the sidecar AIShell even when PowerShell is busy running a command. The posted code will be inserted into prompt after PowerShell finishes running the current command.

- Add `-PostCode`, `-CopyCode`, and `-Exit` parameters to `Invoke-AIShell` in their separate parameter sets. So, a user don't have to leave the PowerShell session they are working in -- they can send query, copy or post code from the AI response, and exit the sidecar AIShell directly from the PowerShell session.
- When the `CodePost` message comes in, the `AIShell` module will check if `PSReadLine` is active (whether PSReadLine is running to process user input). If it's active, we revert the current line and insert the posted code; if it's not, then we register a subscriber to the `OnIdle` event, and the event handler will insert the posted code when PowerShell becomes idle.