### PR TITLE
Publish artifacts in deploy box

### DIFF
--- a/.pipelines/Package-Official.yml
+++ b/.pipelines/Package-Official.yml
@@ -52,8 +52,7 @@ extends:
         Network: KS3
       WindowsHostVersion:
         Version: 2022
-        # Azure container/blob operations get blocked when using KS3
-        Network: KS2
+        Network: KS3
     globalSdl:
       disableLegacyManifest: true
       # disabled Armorty as we dont have any ARM templates to scan. It fails on some sample ARM templates.

--- a/.pipelines/Release-Official.yml
+++ b/.pipelines/Release-Official.yml
@@ -5,6 +5,10 @@ parameters: # parameters are shown up in ADO UI in a build queue time
     displayName: 'Enable debug output'
     type: boolean
     default: false
+  - name: 'publish'
+    displayName: 'Publish artifacts'
+    type: boolean
+    default: true
 
 variables:
   - name: CDP_DEFINITION_BUILD_COUNT
@@ -36,6 +40,8 @@ resources:
 extends:
   template: v2/OneBranch.Official.CrossPlat.yml@templates
   parameters:
+    release:
+      category: NonAzure
     cloudvault:
       enabled: false
     featureFlags:
@@ -43,8 +49,7 @@ extends:
         Network: KS3
       WindowsHostVersion:
         Version: 2022
-        # Azure container/blob operations get blocked when using KS3
-        Network: KS2
+        Network: KS3
     globalSdl:
       asyncSdl:
         enabled: true
@@ -108,22 +113,28 @@ extends:
       dependsOn: UpdateChangeLog
       jobs:
       - template: /.pipelines/templates/release-publish-github.yml@self
+        parameters:
+          publish: ${{ parameters.publish }}
 
     - stage: PublishNuGet
       displayName: Publish NuGet
       dependsOn: PublishGitHubRelease
+      variables:
+        ob_release_environment: Production
       jobs:
       - template: /.pipelines/templates/release-publish-nuget.yml@self
         parameters:
-          publish: true
+          publish: ${{ parameters.publish }}
 
     - stage: PublishModule
       displayName: Publish Module
       dependsOn: PublishGitHubRelease
+      variables:
+        ob_release_environment: Production
       jobs:
       - template: /.pipelines/templates/release-publish-module.yml@self
         parameters:
-          publish: true
+          publish: ${{ parameters.publish }}
 
     - stage: PublishMsix
       dependsOn: PublishGitHubRelease

--- a/.pipelines/templates/module-package.yml
+++ b/.pipelines/templates/module-package.yml
@@ -17,7 +17,7 @@ jobs:
     - group: DotNetPrivateBuildAccess
     - group: certificate_logical_to_actual
     - name: ob_sdl_sbom_enabled
-      value: false
+      value: true
     - name: ob_outputDirectory
       value: '$(Build.ArtifactStagingDirectory)/ONEBRANCH_ARTIFACT'
     - name: repoRoot

--- a/.pipelines/templates/nupkg-package.yml
+++ b/.pipelines/templates/nupkg-package.yml
@@ -26,7 +26,7 @@ jobs:
     - group: mscodehub-feed-read-akv
     - group: DotNetPrivateBuildAccess
     - name: ob_sdl_sbom_enabled
-      value: false
+      value: true
     - name: ob_sdl_codeql_compiled_enabled
       value: false
 

--- a/.pipelines/templates/release-publish-github.yml
+++ b/.pipelines/templates/release-publish-github.yml
@@ -1,3 +1,8 @@
+parameters:
+  - name: publish
+    default: false
+    type: boolean
+
 jobs:
 - job: GithubReleaseDraft
   displayName: Create GitHub Release Draft
@@ -84,6 +89,7 @@ jobs:
       $description = '<!-- TODO: Generate release notes on GitHub! -->'
       Publish-ReleaseDraft -Tag $releaseTag -Name "$releaseTag Release of AIShell" -Description $description -User PowerShell -Repository AIShell -PackageFolder $(PackagesRoot) -Token $(GitHubReleasePat)
     displayName: Publish Release Draft
+    condition: and(ne('${{ parameters.publish }}', 'false'), succeeded())
 
 - template: /.pipelines/templates/wait-for-approval.yml@self
   parameters:

--- a/.pipelines/templates/release-publish-module.yml
+++ b/.pipelines/templates/release-publish-module.yml
@@ -6,6 +6,14 @@ parameters:
 jobs:
 - job: ModulePublish
   displayName: Publish to PSGallery
+  pool:
+    type: release
+    os: windows
+  templateContext:
+    inputs:
+      - input: pipelineArtifact
+        pipeline: AIShellPackagePipeline
+        artifactName: drop_module_package
   variables:
     - name: ob_outputDirectory
       value: '$(Build.ArtifactStagingDirectory)/ONEBRANCH_ARTIFACT'
@@ -16,16 +24,13 @@ jobs:
       value: false
     - name: ob_sdl_codeql_compiled_enabled
       value: false
-  pool:
-    type: windows
 
   steps:
-  - download: AIShellPackagePipeline
-    artifact: drop_module_package
-    displayName: Download module package
-
-  - pwsh: |
-      Get-ChildItem '$(Pipeline.Workspace)/AIShellPackagePipeline/drop_module_package/*.nupkg' -recurse
+  - task: PowerShell@2
+    inputs:
+      targetType: 'inline'
+      script: |
+        Get-ChildItem '$(Pipeline.Workspace)/*.nupkg' -recurse
     displayName: List nupkg package
 
   - task: NuGetCommand@2
@@ -33,6 +38,6 @@ jobs:
     condition: and(ne('${{ parameters.publish }}', 'false'), succeeded())
     inputs:
       command: push
-      packagesToPush: '$(Pipeline.Workspace)/AIShellPackagePipeline/drop_module_package/*.nupkg'
+      packagesToPush: '$(Pipeline.Workspace)/*.nupkg'
       nuGetFeedType: external
       publishFeedCredentials: PowerShellGallery-dongbow

--- a/.pipelines/templates/release-publish-module.yml
+++ b/.pipelines/templates/release-publish-module.yml
@@ -15,8 +15,6 @@ jobs:
         pipeline: AIShellPackagePipeline
         artifactName: drop_module_package
   variables:
-    - name: ob_outputDirectory
-      value: '$(Build.ArtifactStagingDirectory)/ONEBRANCH_ARTIFACT'
     # Disable SBOM, signing, and codeQL for this job
     - name: ob_sdl_sbom_enabled
       value: false

--- a/.pipelines/templates/release-publish-nuget.yml
+++ b/.pipelines/templates/release-publish-nuget.yml
@@ -8,19 +8,24 @@ jobs:
   displayName: Publish to NuGet
   condition: succeeded()
   pool:
-    type: windows
+    type: release
+    os: windows
+  templateContext:
+    inputs:
+      - input: pipelineArtifact
+        pipeline: AIShellPackagePipeline
+        artifactName: drop_nupkg_package
   variables:
   - group: 'mscodehub-code-read-akv'
   - name: ob_outputDirectory
     value: '$(Build.ArtifactStagingDirectory)/ONEBRANCH_ARTIFACT'
 
   steps:
-  - download: AIShellPackagePipeline
-    artifact: drop_nupkg_package
-    displayName: Download nuget packages
-
-  - pwsh: |
-      Get-ChildItem '$(Pipeline.Workspace)/AIShellPackagePipeline/drop_nupkg_package/*.nupkg' -recurse
+   - task: PowerShell@2
+    inputs:
+      targetType: 'inline'
+      script: |
+        Get-ChildItem '$(Pipeline.Workspace)/drop_nupkg_package/*.nupkg' -recurse
     displayName: List nupkg package
 
   - task: NuGetCommand@2
@@ -28,6 +33,6 @@ jobs:
     condition: and(ne('${{ parameters.publish }}', 'false'), succeeded())
     inputs:
       command: push
-      packagesToPush: '$(Pipeline.Workspace)/AIShellPackagePipeline/drop_nupkg_package/*.nupkg'
+      packagesToPush: '$(Pipeline.Workspace)/drop_nupkg_package/*.nupkg'
       nuGetFeedType: external
       publishFeedCredentials: PowerShellNuGetOrgPush

--- a/.pipelines/templates/release-publish-nuget.yml
+++ b/.pipelines/templates/release-publish-nuget.yml
@@ -16,16 +16,20 @@ jobs:
         pipeline: AIShellPackagePipeline
         artifactName: drop_nupkg_package
   variables:
-  - group: 'mscodehub-code-read-akv'
-  - name: ob_outputDirectory
-    value: '$(Build.ArtifactStagingDirectory)/ONEBRANCH_ARTIFACT'
+    # Disable SBOM, signing, and codeQL for this job
+    - name: ob_sdl_sbom_enabled
+      value: false
+    - name: ob_signing_setup_enabled
+      value: false
+    - name: ob_sdl_codeql_compiled_enabled
+      value: false
 
   steps:
-   - task: PowerShell@2
+  - task: PowerShell@2
     inputs:
       targetType: 'inline'
       script: |
-        Get-ChildItem '$(Pipeline.Workspace)/drop_nupkg_package/*.nupkg' -recurse
+        Get-ChildItem '$(Pipeline.Workspace)/*.nupkg' -recurse
     displayName: List nupkg package
 
   - task: NuGetCommand@2
@@ -33,6 +37,6 @@ jobs:
     condition: and(ne('${{ parameters.publish }}', 'false'), succeeded())
     inputs:
       command: push
-      packagesToPush: '$(Pipeline.Workspace)/drop_nupkg_package/*.nupkg'
+      packagesToPush: '$(Pipeline.Workspace)/*.nupkg'
       nuGetFeedType: external
       publishFeedCredentials: PowerShellNuGetOrgPush


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Use deploy box to publish artifacts to nuget.org and powershellgallery.com.

1. Use `KS3` in all places.
2. Expose the parameter 'publish' for the release pipeline, so we can control if we really want to publish artifacts for the release.
3. Use deploy box to publish artifacts to nuget.org and powershellgallery.com


The pipeline runs to verify the changes:
Building: https://dev.azure.com/mscodehub/PowerShellCore/_build/results?buildId=581933&view=results
Packaging: https://dev.azure.com/mscodehub/PowerShellCore/_build/results?buildId=581955&view=results
Releasing: https://dev.azure.com/mscodehub/PowerShellCore/_build/results?buildId=581967&view=results



