### PR TITLE
Fix code posting on macOS

### DIFF
--- a/shell/AIShell.Integration/AIShell.psm1
+++ b/shell/AIShell.Integration/AIShell.psm1
@@ -1,6 +1,6 @@
 $module = Get-Module -Name PSReadLine
-if ($null -eq $module -or $module.Version -lt [version]"2.4.1") {
-    throw "The PSReadLine v2.4.1-beta1 or higher is required for the AIShell module to work properly."
+if ($null -eq $module -or $module.Version -lt [version]"2.4.2") {
+    throw "The PSReadLine v2.4.2-beta2 or higher is required for the AIShell module to work properly."
 }
 
 ## Create the channel singleton when loading the module.


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Fix #172

This PR fixes the following scenarios on macOS
1. Running `/code post` from the `AIShell` pane to post code to the `PowerShell` pane
2. Running `Invoke-AIShell -PostCode` from the `PowerShell` to request code to be posted from the `AIShell` pane.

**[NOTE]** Now the `AIShell` module depends on the **v2.4.2-beta2** PSReadLine, because a private field was added in PSReadLine to accurately indicate if PSReadLine is initialized and ready to render (https://github.com/PowerShell/PSReadLine/pull/4706).

The `AIShell` module starts to depend on that field to be more deterministic about if PSReadLine is running and ready. Before this change, we relied on `Console.TreatControlCAsInput` which is not accurate and may cause race condition: `Console.TreatControlCAsInput` is set to true, but `Initialize(...)` is not called yet. Rendering the posted code before initialization could result in corrupted state -- posted code may be rendered on wrong position, or even cause exception.