### PR TITLE
Update model information to support the new OpenAI models

### DIFF
--- a/shell/agents/AIShell.OpenAI.Agent/ModelInfo.cs
+++ b/shell/agents/AIShell.OpenAI.Agent/ModelInfo.cs
@@ -25,7 +25,10 @@ internal class ModelInfo
         // https://github.com/openai/openai-cookbook/blob/main/examples/How_to_count_tokens_with_tiktoken.ipynb
         s_modelMap = new(StringComparer.OrdinalIgnoreCase)
         {
-            ["o1"]            = new(tokenLimit: 200_000, encoding: Gpt4oEncoding),
+            ["o1"]            = new(tokenLimit: 200_000, encoding: Gpt4oEncoding, reasoning: true),
+            ["o3"]            = new(tokenLimit: 200_000, encoding: Gpt4oEncoding, reasoning: true),
+            ["o4-mini"]       = new(tokenLimit: 200_000, encoding: Gpt4oEncoding, reasoning: true),
+            ["gpt-4.1"]       = new(tokenLimit: 1_047_576, encoding: Gpt4oEncoding),
             ["gpt-4o"]        = new(tokenLimit: 128_000, encoding: Gpt4oEncoding),
             ["gpt-4"]         = new(tokenLimit: 8_192),
             ["gpt-4-32k"]     = new(tokenLimit: 32_768),
@@ -45,7 +48,7 @@ internal class ModelInfo
         };
     }
 
-    private ModelInfo(int tokenLimit, string encoding = null)
+    private ModelInfo(int tokenLimit, string encoding = null, bool reasoning = false)
     {
         TokenLimit = tokenLimit;
         _encodingName = encoding ?? Gpt34Encoding;
@@ -54,6 +57,7 @@ internal class ModelInfo
         // See https://github.com/openai/openai-cookbook/blob/main/examples/How_to_count_tokens_with_tiktoken.ipynb
         TokensPerMessage = 3;
         TokensPerName = 1;
+        Reasoning = reasoning;
     }
 
     private readonly string _encodingName;
@@ -62,6 +66,7 @@ internal class ModelInfo
     internal int TokenLimit { get; }
     internal int TokensPerMessage { get; }
     internal int TokensPerName { get; }
+    internal bool Reasoning { get; }
     internal Tokenizer Encoding
     {
         get {

--- a/shell/agents/AIShell.OpenAI.Agent/Service.cs
+++ b/shell/agents/AIShell.OpenAI.Agent/Service.cs
@@ -35,7 +35,6 @@ internal class ChatService
 
         _chatOptions = new ChatCompletionOptions()
         {
-            Temperature = 0,
             MaxOutputTokenCount = MaxResponseToken,
         };
     }
@@ -126,6 +125,8 @@ internal class ChatService
         }
 
         EndpointType type = _gptToUse.Type;
+        // Reasoning models do not support the temperature setting.
+        _chatOptions.Temperature = _gptToUse.ModelInfo.Reasoning ? null : 0;
 
         if (type is EndpointType.AzureOpenAI)
         {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Fix #360

Update model information to support the new OpenAI models.

- The OpenAI reasoning models do not support the `temperature` setting -- they error out if you set the value. But the `DeepSeek R1` OpenAI compatible API still allows passing the `temperature` setting even though it has not effect.

- I don't have access to the `o3` model (requires verifying organization), but I've verified the changes with `o1`, `o3-mini`, `o4-mini`, `gpt-4.1`, `gpt-4.1-mini`, and `gpt-4.1-nano` modules and it works fine.

- The `o1-mini` model doesn't work because it doesn't support the system prompt (very weird). Given that the `o3-mini` is out and recommended, I think it's fine to not work with `o1-mini`.

Regarding the reasoning/thinking tokens:

- The OpenAI reasoning models do not expose the Chain of Thoughts (CoT) tokens. They may provide a summary but that is not available with the `Chat Completion APIs` ([see details here](https://platform.openai.com/docs/guides/reasoning?api-mode=chat#reasoning-summaries)).

- The `DeepSeek R1` exposes the CoT tokens and has a really nice way of dealing with it in their version of OpenAI compatible `Chat Completion APIs` (see its [reasoning model doc](https://api-docs.deepseek.com/guides/reasoning_model) for details). However, the .NET OpenAI SDK doesn't expose `reasoning_content` today. The tracking issue is https://github.com/openai/openai-dotnet/issues/259#issuecomment-2614483337
   > reasoning_content：The content of the CoT, which is at the same level as content in the output structure.

- The `Gemini` thinking models also exposes the CoT tokens but is limited with the OpenAI compatible APIs today. See https://discuss.ai.google.dev/t/reasoning-tokens-combined-with-completion-tokens-in-openai-compatibility-mode/58354/7?utm_source=chatgpt.com for details. It may support exposing CoT tokens with the same way as `DeepSeek R1` in future.

We will work on supporting the CoT tokens once .NET OpenAI SDK is fixed to expose the `reasoning_content` field.