### PR TITLE
Adding Phi Silica Agent for Copilot+PCs

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -53,7 +53,7 @@ function Start-Build
     }
 
     if (HasUnapplicableAgent $AgentToInclude) {
-        throw "One or more specified agents cannot be built on the current platform: $($windowsOnlyAgents -join ', ').`nPlease skip them and try again."
+        throw "The following specified agent(s) cannot be built on the current platform: $($windowsOnlyAgents -join ', ')."
     }
 
     $RID = $Runtime ?? (dotnet --info |

--- a/build.psm1
+++ b/build.psm1
@@ -20,7 +20,7 @@ function Start-Build
         [string] $Runtime = [NullString]::Value,
 
         [Parameter()]
-        [ValidateSet('openai-gpt', 'msaz', 'interpreter', 'ollama')]
+        [ValidateSet('openai-gpt', 'msaz', 'interpreter', 'ollama', 'phisilica')]
         [string[]] $AgentToInclude,
 
         [Parameter()]
@@ -69,6 +69,7 @@ function Start-Build
     $msaz_dir = Join-Path $agent_dir "Microsoft.Azure.Agent"
     $interpreter_agent_dir = Join-Path $agent_dir "AIShell.Interpreter.Agent"
     $ollama_agent_dir = Join-Path $agent_dir "AIShell.Ollama.Agent"
+    $phisilica_agent_dir = Join-Path $agent_dir "AIShell.PhiSilica.Agent"
 
     $config = $Configuration.ToLower()
     $out_dir = Join-Path $PSScriptRoot "out"
@@ -79,6 +80,7 @@ function Start-Build
     $msaz_out_dir = Join-Path $app_out_dir "agents" "Microsoft.Azure.Agent"
     $interpreter_out_dir = Join-Path $app_out_dir "agents" "AIShell.Interpreter.Agent"
     $ollama_out_dir =  Join-Path $app_out_dir "agents" "AIShell.Ollama.Agent"
+    $phisilica_out_dir = Join-Path $app_out_dir "agents" "AIShell.PhiSilica.Agent"
 
     if ($Clean) {
         if (Test-Path $out_dir) {
@@ -150,6 +152,12 @@ function Start-Build
         Write-Host "`n[Build the Ollama agent ...]`n" -ForegroundColor Green
         $ollama_csproj = GetProjectFile $ollama_agent_dir
         dotnet publish $ollama_csproj -c $Configuration -o $ollama_out_dir
+    }
+
+    if ($LASTEXITCODE -eq 0 -and $AgentToInclude -contains 'phisilica') {
+        Write-Host "`n[Build the PhiSilica agent ...]`n" -ForegroundColor Green
+        $phisilica_csproj = GetProjectFile $phisilica_agent_dir
+        dotnet publish $phisilica_csproj -c $Configuration -o $phisilica_out_dir
     }
 
     if ($LASTEXITCODE -eq 0 -and -not $NotIncludeModule) {

--- a/shell/agents/AIShell.PhiSilica.Agent/AIShell.PhiSilica.Agent.csproj
+++ b/shell/agents/AIShell.PhiSilica.Agent/AIShell.PhiSilica.Agent.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+	  <OutputType>Library</OutputType>
+	  <TargetFramework>net8.0-windows10.0.26100.0</TargetFramework>
+	  <ImplicitUsings>enable</ImplicitUsings>
+	  <Nullable>enable</Nullable>
+	  <Platforms>AnyCPU</Platforms>
+	  <WindowsPackageType>None</WindowsPackageType>
+	  <EnableDynamicLoading>true</EnableDynamicLoading>
+	  <WindowsAppSdkBootstrapInitialize>true</WindowsAppSdkBootstrapInitialize>
+	  <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
+	  <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
+      <EnableMsixTooling>true</EnableMsixTooling>
+
+  </PropertyGroup>
+
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\AIShell.Abstraction\AIShell.Abstraction.csproj">
+      <!-- Disable copying AIShell.Abstraction.dll to output folder -->
+      <Private>false</Private>
+      <!-- Disable copying the transitive dependencies to output folder -->
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </ProjectReference>
+  </ItemGroup>
+
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.250410001-experimental1" />
+  </ItemGroup>
+
+</Project>

--- a/shell/agents/AIShell.PhiSilica.Agent/AIShell.PhiSilica.Agent.csproj
+++ b/shell/agents/AIShell.PhiSilica.Agent/AIShell.PhiSilica.Agent.csproj
@@ -1,20 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-	  <OutputType>Library</OutputType>
-	  <TargetFramework>net8.0-windows10.0.26100.0</TargetFramework>
-	  <ImplicitUsings>enable</ImplicitUsings>
-	  <Nullable>enable</Nullable>
-	  <Platforms>AnyCPU</Platforms>
-	  <WindowsPackageType>None</WindowsPackageType>
-	  <EnableDynamicLoading>true</EnableDynamicLoading>
-	  <WindowsAppSdkBootstrapInitialize>true</WindowsAppSdkBootstrapInitialize>
-	  <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
-	  <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
-      <EnableMsixTooling>true</EnableMsixTooling>
-
+    <OutputType>Library</OutputType>
+    <TargetFramework>net8.0-windows10.0.26100.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <NoWarn>CS8305</NoWarn>
+    <Platforms>AnyCPU</Platforms>
+    <WindowsPackageType>None</WindowsPackageType>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
+    <WindowsAppSdkBootstrapInitialize>true</WindowsAppSdkBootstrapInitialize>
+    <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
+    <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
+    <EnableMsixTooling>true</EnableMsixTooling>
   </PropertyGroup>
-
 
   <ItemGroup>
     <ProjectReference Include="..\..\AIShell.Abstraction\AIShell.Abstraction.csproj">
@@ -24,7 +21,6 @@
       <ExcludeAssets>runtime</ExcludeAssets>
     </ProjectReference>
   </ItemGroup>
-
 
   <ItemGroup>
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.250410001-experimental1" />

--- a/shell/agents/AIShell.PhiSilica.Agent/PhiSilicaAgent.cs
+++ b/shell/agents/AIShell.PhiSilica.Agent/PhiSilicaAgent.cs
@@ -1,0 +1,69 @@
+
+using Microsoft.Windows.AI.Generative;
+
+using AIShell.Abstraction;
+using Microsoft.Windows.AI;
+
+namespace phisilicaagent_041825
+{
+    public class PhiSilicaAgent : ILLMAgent
+    {
+        public string Name => "PhiSilica";
+
+        public string Description => "This is the Phi Silica agent, an offline local agent on Copilot+ PCs";
+
+        public string SettingFile => null;
+
+        public bool CanAcceptFeedback(UserAction action) => false;
+
+
+        public async Task<bool> ChatAsync(string input, IShell shell)
+        {
+            IHost host = shell.Host;
+            if (LanguageModel.GetReadyState() == AIFeatureReadyState.EnsureNeeded)
+            {
+                var op = await LanguageModel.EnsureReadyAsync();
+
+            }
+
+            var languageModel = await LanguageModel.CreateAsync();
+
+            var results = await languageModel.GenerateResponseAsync(input);
+
+            if (results != null && !string.IsNullOrEmpty(results.Text))
+            {
+                host.RenderFullResponse(results.Text);
+            }
+            else
+            {
+                host.WriteErrorLine("No response received from the language model.");
+            }
+            //host.RenderFullResponse("Goodbye World");
+
+            return true;
+        }
+
+        public void Dispose()
+        {
+           
+        }
+
+        public IEnumerable<CommandBase> GetCommands() => null;
+
+        public void Initialize(AgentConfig config)
+        {
+            
+        }
+
+        public void OnUserAction(UserActionPayload actionPayload)
+        {
+            
+        }
+
+        public Task RefreshChatAsync(IShell shell, bool force)
+        {
+            return Task.CompletedTask;
+        }
+    }
+
+}

--- a/shell/agents/AIShell.PhiSilica.Agent/PhiSilicaAgent.cs
+++ b/shell/agents/AIShell.PhiSilica.Agent/PhiSilicaAgent.cs
@@ -4,7 +4,7 @@ using Microsoft.Windows.AI.Generative;
 using AIShell.Abstraction;
 using Microsoft.Windows.AI;
 
-namespace phisilicaagent_041825
+namespace AIShell.PhiSilica.Agent
 {
     public class PhiSilicaAgent : ILLMAgent
     {

--- a/shell/agents/AIShell.PhiSilica.Agent/PhiSilicaAgent.cs
+++ b/shell/agents/AIShell.PhiSilica.Agent/PhiSilicaAgent.cs
@@ -10,7 +10,7 @@ public sealed partial class PhiSilicaAgent : ILLMAgent
     private LanguageModel _model;
 
     public string Name => "PhiSilica";
-    public string Description => "This is the Phi Silica agent, an offline local agent on Copilot+ PCs";
+    public string Description => "This is the AI Shell Agent for talking to the inbox Phi Silica model on Copilot+ PCs.";
     public string SettingFile => null;
 
     public IEnumerable<CommandBase> GetCommands() => null;

--- a/shell/agents/AIShell.PhiSilica.Agent/PhiSilicaAgent.cs
+++ b/shell/agents/AIShell.PhiSilica.Agent/PhiSilicaAgent.cs
@@ -1,69 +1,97 @@
-
-using Microsoft.Windows.AI.Generative;
-
 using AIShell.Abstraction;
 using Microsoft.Windows.AI;
+using Microsoft.Windows.AI.Generative;
 
-namespace AIShell.PhiSilica.Agent
+namespace AIShell.PhiSilica.Agent;
+
+public sealed partial class PhiSilicaAgent : ILLMAgent
 {
-    public class PhiSilicaAgent : ILLMAgent
+    private readonly Task _initTask;
+    private LanguageModel _model;
+
+    public string Name => "PhiSilica";
+    public string Description => "This is the Phi Silica agent, an offline local agent on Copilot+ PCs";
+    public string SettingFile => null;
+
+    public IEnumerable<CommandBase> GetCommands() => null;
+    public bool CanAcceptFeedback(UserAction action) => false;
+    public Task RefreshChatAsync(IShell shell, bool force) => Task.CompletedTask;
+    public void OnUserAction(UserActionPayload actionPayload) { }
+    public void Initialize(AgentConfig config) { }
+    public void Dispose() { }
+
+    public PhiSilicaAgent()
     {
-        public string Name => "PhiSilica";
-
-        public string Description => "This is the Phi Silica agent, an offline local agent on Copilot+ PCs";
-
-        public string SettingFile => null;
-
-        public bool CanAcceptFeedback(UserAction action) => false;
-
-
-        public async Task<bool> ChatAsync(string input, IShell shell)
-        {
-            IHost host = shell.Host;
-            if (LanguageModel.GetReadyState() == AIFeatureReadyState.EnsureNeeded)
-            {
-                var op = await LanguageModel.EnsureReadyAsync();
-
-            }
-
-            var languageModel = await LanguageModel.CreateAsync();
-
-            var results = await languageModel.GenerateResponseAsync(input);
-
-            if (results != null && !string.IsNullOrEmpty(results.Text))
-            {
-                host.RenderFullResponse(results.Text);
-            }
-            else
-            {
-                host.WriteErrorLine("No response received from the language model.");
-            }
-            //host.RenderFullResponse("Goodbye World");
-
-            return true;
-        }
-
-        public void Dispose()
-        {
-           
-        }
-
-        public IEnumerable<CommandBase> GetCommands() => null;
-
-        public void Initialize(AgentConfig config)
-        {
-            
-        }
-
-        public void OnUserAction(UserActionPayload actionPayload)
-        {
-            
-        }
-
-        public Task RefreshChatAsync(IShell shell, bool force)
-        {
-            return Task.CompletedTask;
-        }
+        // Start the initialization for AI feature and model on a background thread.
+        _initTask = Task.Run(InitFeatureAndModelAsync);
     }
 
+    private async Task InitFeatureAndModelAsync()
+    {
+        AIFeatureReadyState state = LanguageModel.GetReadyState();
+        if (state is AIFeatureReadyState.NotSupportedOnCurrentSystem)
+        {
+            throw new PlatformNotSupportedException("The Phi Silica feature is not supported on current system.");
+        }
+
+        if (state is AIFeatureReadyState.DisabledByUser)
+        {
+            throw new PlatformNotSupportedException("The Phi Silica feature is currently disabled.");
+        }
+
+        if (state is AIFeatureReadyState.EnsureNeeded)
+        {
+            // Initialize the WinRT runtime.
+            AIFeatureReadyResult result = await LanguageModel.EnsureReadyAsync();
+            // Do not proceed if it failed to get the feature ready.
+            if (result.Status is not AIFeatureReadyResultState.Success)
+            {
+                throw new InvalidOperationException(result.ErrorDisplayText, result.Error);
+            }
+        }
+
+        _model = await LanguageModel.CreateAsync();
+    }
+
+    public async Task<bool> ChatAsync(string input, IShell shell)
+    {
+        IHost host = shell.Host;
+
+        try
+        {
+            // Wait for the init task to finish. Once it's finished, calling this again is a non-op.
+            await _initTask;
+        }
+        catch (Exception e)
+        {
+            host.WriteErrorLine(e.Message);
+            if (e is InvalidOperationException && e.InnerException is not null)
+            {
+                host.WriteErrorLine(e.InnerException.StackTrace);
+            }
+            else if (e is not PlatformNotSupportedException)
+            {
+                // Show stack trace for non-PNS exception.
+                host.WriteErrorLine(e.StackTrace);
+            }
+
+            return false;
+        }
+
+        var result = await host.RunWithSpinnerAsync(
+            status: "Thinking ...",
+            func: async () => await _model.GenerateResponseAsync(input)
+        );
+
+        if (result is not null && !string.IsNullOrEmpty(result.Text))
+        {
+            host.RenderFullResponse(result.Text);
+        }
+        else
+        {
+            host.WriteErrorLine("No response received from the language model.");
+        }
+
+        return true;
+    }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This is implementation of an agent for PhiSilica or Copilot+ PCs. This enables AI shell to be used in offline scenarios using the onboard SLM Phi Silica on Copilot+PCs. 
## Todos

- [x] "Thinking" Icon while loading
- [ ] Add history context sharing
- [x] Update descriptions etc.
