### PR TITLE
Update installation script to install `AIShell` module on macOS too

### DIFF
--- a/shell/AIShell.Integration/AIShell.psm1
+++ b/shell/AIShell.Integration/AIShell.psm1
@@ -1,3 +1,7 @@
+if ($IsMacOS -and $env:TERM_PROGRAM -ne "iTerm.app") {
+    throw "The AIShell module requires iTerm2 to work properly. Please install and run from the iTerm2 terminal."
+}
+
 $module = Get-Module -Name PSReadLine
 if ($null -eq $module -or $module.Version -lt [version]"2.4.2") {
     throw "The PSReadLine v2.4.2-beta2 or higher is required for the AIShell module to work properly."

--- a/tools/scripts/install-aishell.ps1
+++ b/tools/scripts/install-aishell.ps1
@@ -95,6 +95,7 @@ function Install-AIShellApp {
 
     if (-not $destinationExists) {
         # Create the directory if not existing.
+        Write-Host "Creating the target folder '$destination' ..."
         if ($IsWindows) {
             $null = New-Item -Path $destination -ItemType Directory -Force
         } else {

--- a/tools/scripts/install-aishell.ps1
+++ b/tools/scripts/install-aishell.ps1
@@ -204,13 +204,12 @@ function Uninstall-AIShellApp {
 }
 
 function Install-AIShellModule {
-    if ($IsWindows) {
-        $modVersion = $Script:ModuleVersion
-        Write-Host "Installing the PowerShell module 'AIShell' $modVersion ..."
-        Install-PSResource -Name AIShell -Repository PSGallery -Prerelease -TrustRepository -Version $modVersion -ErrorAction Stop -WarningAction SilentlyContinue
-    } else {
-        Write-Host -ForegroundColor Yellow "Currently the AIShell PowerShell module will only work in iTerm2 terminal and still has limited support but if you would like to test it, you can install it with 'Install-PSResource -Name AIShell -Repository PSGallery -Prerelease'."
-        Write-Host -ForegroundColor Yellow "The AI Shell app has been added to your path, please run 'aish' to use the standalone experience."
+    $modVersion = $Script:ModuleVersion
+    Write-Host "Installing the PowerShell module 'AIShell' $modVersion ..."
+    Install-PSResource -Name AIShell -Repository PSGallery -Prerelease -TrustRepository -Version $modVersion -ErrorAction Stop -WarningAction SilentlyContinue
+
+    if ($IsMacOS) {
+        Write-Host -ForegroundColor Yellow "NOTE: The 'AIShell' PowerShell module only works in iTerm2 terminal in order to provide the sidecar experience."
     }
 }
 
@@ -237,12 +236,16 @@ if ($Uninstall) {
     Uninstall-AIShellApp
     Uninstall-AIShellModule
 
-    $message = $IsWindows ? "AI Shell App and PowerShell module have" : "AI Shell App has"
-    Write-Host "`n$message been successfully uninstalled." -ForegroundColor Green
+    Write-Host -ForegroundColor Green "`nAI Shell App and PowerShell module have been successfully uninstalled."
 } else {
     Install-AIShellApp
     Install-AIShellModule
 
-    $message = $IsWindows ? "'Start-AIShell'" : "'aish'"
-    Write-Host "`nInstallation succeeded.`nTo learn more about AI Shell please visit https://aka.ms/AIShell-Docs.`nTo get started please run $message to start AI Shell." -ForegroundColor Green
+    $condition = $IsMacOS ? " if you are in iTerm2" : $null
+    Write-Host -ForegroundColor Green -Object @"
+
+Installation succeeded.
+To learn more about AI Shell please visit https://aka.ms/AIShell-Docs.
+To get started, please run 'Start-AIShell' to use the sidecar experience${condition}, or run 'aish' to use the standalone experience.
+"@
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Since the integration experience is mostly fixed on macOS, we should install `AIShell` module on macOS too.
- Update the `AIShell` module to check if it's running in iTerm2, and throw if not
- Update the installation script to install `AIShell` module on macOS
- Update the messages in installation script accordingly

