### PR TITLE
Merge the 1.0.0-preview.4 release branch back to main

### DIFF
--- a/.pipelines/Release-Official.yml
+++ b/.pipelines/Release-Official.yml
@@ -111,6 +111,8 @@ extends:
     - stage: PublishGitHubRelease
       displayName: Publish GitHub Release
       dependsOn: UpdateChangeLog
+      variables:
+        ob_release_environment: Production
       jobs:
       - template: /.pipelines/templates/release-publish-github.yml@self
         parameters:

--- a/.pipelines/templates/linux-package.yml
+++ b/.pipelines/templates/linux-package.yml
@@ -19,7 +19,7 @@ jobs:
       value: true
     - group: DotNetPrivateBuildAccess
     - name: ob_sdl_sbom_enabled
-      value: false
+      value: true
     - name: ob_sdl_codeql_compiled_enabled
       value: false
     - name: ob_outputDirectory

--- a/.pipelines/templates/mac-package.yml
+++ b/.pipelines/templates/mac-package.yml
@@ -24,7 +24,7 @@ jobs:
       value: true
     - group: DotNetPrivateBuildAccess
     - name: ob_sdl_sbom_enabled
-      value: false
+      value: true
     - name: ob_sdl_codeql_compiled_enabled
       value: false
     - name: ob_outputDirectory

--- a/.pipelines/templates/module-package.yml
+++ b/.pipelines/templates/module-package.yml
@@ -81,7 +81,7 @@ jobs:
       try {
         $RepoName = "PSRLLocal"
         Register-PSResourceRepository -Name $RepoName -Uri $nugetPath -Trusted
-        Publish-PSResource -Repository $RepoName -Path $moduleFolder
+        Publish-PSResource -Repository $RepoName -Path $moduleFolder -SkipModuleManifestValidate
       } finally {
         Unregister-PSResourceRepository -Name $RepoName -ErrorAction SilentlyContinue
       }

--- a/.pipelines/templates/release-publish-github.yml
+++ b/.pipelines/templates/release-publish-github.yml
@@ -8,7 +8,28 @@ jobs:
   displayName: Create GitHub Release Draft
   condition: succeeded()
   pool:
-    type: windows
+    type: release
+    os: windows
+  templateContext:
+    inputs:
+      - input: pipelineArtifact
+        pipeline: AIShellPackagePipeline
+        artifactName: drop_windows_package_arm64
+      - input: pipelineArtifact
+        pipeline: AIShellPackagePipeline
+        artifactName: drop_windows_package_x64
+      - input: pipelineArtifact
+        pipeline: AIShellPackagePipeline
+        artifactName: drop_windows_package_x86
+      - input: pipelineArtifact
+        pipeline: AIShellPackagePipeline
+        artifactName: drop_linux_package_arm64
+      - input: pipelineArtifact
+        pipeline: AIShellPackagePipeline
+        artifactName: drop_linux_package_x64
+      - input: pipelineArtifact
+        pipeline: AIShellPackagePipeline
+        artifactName: macos-pkgs
   variables:
   - group: 'mscodehub-code-read-akv'
   - group: 'Azure Blob variable group'
@@ -19,90 +40,137 @@ jobs:
     value: $(Build.SourcesDirectory)\AIShell\.config\tsaoptions.json
 
   steps:
-  - checkout: self
-    clean: true
-
-  - pwsh: |
-      Get-ChildItem Env:
+  - task: PowerShell@2
+    inputs:
+      targetType: inline
+      script: |
+        Get-ChildItem Env: | Out-String -Width 500
     displayName: 'Capture Environment Variables'
 
-  - download: AIShellPackagePipeline
-    artifact: drop_windows_package_arm64
-    displayName: Download win-arm64 zip
-    patterns: '**/*.zip'
+  - task: PowerShell@2
+    inputs:
+      targetType: inline
+      script: |
+        $packagesRoot = '$(Pipeline.Workspace)/release'
+        $null = New-Item -ItemType Directory -Path $packagesRoot
+        Get-ChildItem -Path '$(Pipeline.Workspace)/*' -Include *.zip,*.tar.gz |
+          Copy-Item -Destination $packagesRoot -Force -Verbose
 
-  - download: AIShellPackagePipeline
-    artifact: drop_windows_package_x64
-    displayName: Download win-x64 zip
-    patterns: '**/*.zip'
+        Write-Verbose -Verbose "List all packages to be published to GitHub release page:"
+        Get-ChildItem -Path $packagesRoot | Out-String -Width 500
 
-  - download: AIShellPackagePipeline
-    artifact: drop_windows_package_x86
-    displayName: Download win-x86 zip
-    patterns: '**/*.zip'
-  
-  - download: AIShellPackagePipeline
-    artifact: drop_linux_package_arm64
-    displayName: Download linux-arm64 tar.gz
-    patterns: '**/*.tar.gz'
-
-  - download: AIShellPackagePipeline
-    artifact: drop_linux_package_x64
-    displayName: Download linux-x64 tar.gz
-    patterns: '**/*.tar.gz'
-
-  - download: AIShellPackagePipeline
-    artifact: macos-pkgs
-    displayName: Download macOS tar.gz
-    patterns: '**/*.tar.gz'
-
-  - pwsh: |
-      $packagesRoot = '$(Pipeline.Workspace)/release'
-      $null = New-Item -ItemType Directory -Path $packagesRoot
-      Get-ChildItem -Path '$(Pipeline.Workspace)\AIShellPackagePipeline' -Include *.zip,*.tar.gz -Recurse |
-        Copy-Item -Destination $packagesRoot -Force -Verbose
-
-      Write-Verbose -Verbose "List all packages to be published to GitHub release page:"
-      Get-ChildItem -Path $packagesRoot | Out-String -Width 500 -Stream
-
-      $vstsCommandString = "vso[task.setvariable variable=PackagesRoot]$packagesRoot"
-      Write-Host "sending " + $vstsCommandString
-      Write-Host "##$vstsCommandString"
+        $vstsCommandString = "vso[task.setvariable variable=PackagesRoot]$packagesRoot"
+        Write-Host "sending " + $vstsCommandString
+        Write-Host "##$vstsCommandString"
     displayName: Capture downloaded artifacts
 
-  - pwsh: |
-      $macX64File = (Get-Item "$(PackagesRoot)\AIShell-*-osx-x64.tar.gz").Name
-      $releaseVersion = $macX64File.Replace("AIShell-", "").Replace("-osx-x64.tar.gz", "")
+  - task: PowerShell@2
+    inputs:
+      targetType: inline
+      script: |
+        $hashPath = Join-Path $(PackagesRoot) 'hashes.sha256'
+        $checksums = Get-ChildItem -Path $(PackagesRoot) |
+            ForEach-Object {
+                $packageName = $_.Name
+                $fullPath = $_.FullName
+                Write-Verbose -Verbose "Generating checksum for $fullPath"
+                $hash = (Get-FileHash -Path $fullPath -Algorithm SHA256).Hash.ToLower()
+                # the '*' before the packagename signifies it is a binary
+                "$hash *$packageName"
+            }
+        $checksums | Out-File -FilePath $hashPath -Force
+        Get-Content -Path $hashPath -Raw | Out-String -Width 500
+    displayName: Add sha256 hashes
 
-      $vstsCommandString = "vso[task.setvariable variable=ReleaseVersion]$releaseVersion"
-      Write-Host "sending " + $vstsCommandString
-      Write-Host "##$vstsCommandString"
+  - task: PowerShell@2
+    inputs:
+      targetType: inline
+      script: |
+        $macX64File = (Get-Item "$(PackagesRoot)/AIShell-*-osx-x64.tar.gz").Name
+        $releaseVersion = $macX64File.Replace("AIShell-", "").Replace("-osx-x64.tar.gz", "")
+
+        $vstsCommandString = "vso[task.setvariable variable=ReleaseVersion]$releaseVersion"
+        Write-Host "sending " + $vstsCommandString
+        Write-Host "##$vstsCommandString"
     displayName: 'Set release version'
 
-  - pwsh: |
-      git clone https://$(mscodehubCodeReadPat)@mscodehub.visualstudio.com/PowerShellCore/_git/Internal-PowerShellTeam-Tools '$(Pipeline.Workspace)\tools'
-    displayName: Clone Internal-Tools repository
+  - task: PowerShell@2
+    inputs:
+      targetType: inline
+      script: |
+        $content = '<!-- TODO: Generate release notes on GitHub! -->'
+        $StringBuilder = [System.Text.StringBuilder]::new($content, $content.Length + 2kb)
+        $StringBuilder.AppendLine().AppendLine() > $null
+        $StringBuilder.AppendLine("#### SHA256 Hashes of the release artifacts").AppendLine() > $null
+        Get-ChildItem -Path $(PackagesRoot) -File | ForEach-Object {
+            $PackageName = $_.Name
+            $SHA256 = (Get-FileHash -Path $_.FullName -Algorithm SHA256).Hash
+            $StringBuilder.AppendLine("- $PackageName").AppendLine("  - $SHA256") > $null
+        }
 
-  - pwsh: |
-      Import-module '$(Pipeline.Workspace)\tools\Scripts\GitHubRelease.psm1'
-      $releaseTag = 'v$(ReleaseVersion)'
-      $description = '<!-- TODO: Generate release notes on GitHub! -->'
-      Publish-ReleaseDraft -Tag $releaseTag -Name "$releaseTag Release of AIShell" -Description $description -User PowerShell -Repository AIShell -PackageFolder $(PackagesRoot) -Token $(GitHubReleasePat)
-    displayName: Publish Release Draft
+        $content = $StringBuilder.ToString()
+        Write-Verbose -Verbose "Selected content: `n$content"
+        $releaseNotesFilePath = "$(Pipeline.Workspace)/release-notes.md"
+        $content | Out-File -FilePath $releaseNotesFilePath -Encoding utf8
+        Write-Host "##vso[task.setvariable variable=ReleaseNotesFilePath;]$releaseNotesFilePath"
+
+        # If it's prelease then make prerelease true as a variable
+        if ($(ReleaseVersion) -like '*-*') {
+            Write-Host "##vso[task.setvariable variable=IsPreRelease;]true"
+        } else {
+            Write-Host "##vso[task.setvariable variable=IsPreRelease;]false"
+        }
+    displayName: Set variables for GitHub release task
+
+  - task: PowerShell@2
+    inputs:
+      targetType: inline
+      script: |
+        Write-Host "ReleaseNotes content:"
+        Get-Content $(ReleaseNotesFilePath) | Out-String -width 500
+    displayName: Verify Release Notes
+
+  - task: GitHubRelease@1
+    displayName: 'Publish Release Draft'
     condition: and(ne('${{ parameters.publish }}', 'false'), succeeded())
+    inputs:
+      gitHubConnection: GitHubReleasePAT
+      repositoryName: PowerShell/AIShell
+      target: main
+      assets: '$(PackagesRoot)/*'
+      tagSource: 'userSpecifiedTag'
+      tag: 'v$(ReleaseVersion)'
+      title: 'v$(ReleaseVersion) Release of AIShell'
+      isDraft: true
+      addChangeLog: false
+      action: 'create'
+      releaseNotesFilePath: '$(ReleaseNotesFilePath)'
+      isPrerelease: '$(IsPreRelease)'
 
-- template: /.pipelines/templates/wait-for-approval.yml@self
-  parameters:
+- job: PushGitTag
+  dependsOn: GithubReleaseDraft
+  displayName: Push Git Tag
+  pool:
+    type: server
+  timeoutInMinutes: 1440
+
+  steps:
+  - task: ManualValidation@0
     displayName: Push Git Tag
-    jobName: PushGitTag
-    dependsOnJob: GithubReleaseDraft
-    instructions: |
-      Push the git tag to upstream
+    inputs:
+      instructions: Push the git tag to upstream
+      timeoutInMinutes: 1440
 
-- template: /.pipelines/templates/wait-for-approval.yml@self
-  parameters:
+- job: DraftPublic
+  dependsOn: PushGitTag
+  displayName: Make Draft Public
+  pool:
+    type: server
+  timeoutInMinutes: 1440
+
+  steps:
+  - task: ManualValidation@0
     displayName: Make Draft Public
-    jobName: DraftPublic
-    dependsOnJob: PushGitTag
-    instructions: |
-      Make the GitHub Release Draft Public
+    inputs:
+      instructions: Make the GitHub Release Draft Public
+      timeoutInMinutes: 1440

--- a/.pipelines/templates/release-publish-github.yml
+++ b/.pipelines/templates/release-publish-github.yml
@@ -31,9 +31,6 @@ jobs:
         pipeline: AIShellPackagePipeline
         artifactName: macos-pkgs
   variables:
-  - group: 'mscodehub-code-read-akv'
-  - group: 'Azure Blob variable group'
-  - group: 'GitHubTokens'
   - name: ob_outputDirectory
     value: '$(Build.ArtifactStagingDirectory)/ONEBRANCH_ARTIFACT'
   - name: ob_sdl_tsa_configFile
@@ -134,7 +131,7 @@ jobs:
     displayName: 'Publish Release Draft'
     condition: and(ne('${{ parameters.publish }}', 'false'), succeeded())
     inputs:
-      gitHubConnection: GitHubReleasePAT
+      gitHubConnection: ReleaseToAIShellRepo
       repositoryName: PowerShell/AIShell
       target: main
       assets: '$(PackagesRoot)/*'

--- a/.pipelines/templates/release-publish-github.yml
+++ b/.pipelines/templates/release-publish-github.yml
@@ -115,7 +115,7 @@ jobs:
         Write-Host "##vso[task.setvariable variable=ReleaseNotesFilePath;]$releaseNotesFilePath"
 
         # If it's prelease then make prerelease true as a variable
-        if ($(ReleaseVersion) -like '*-*') {
+        if ('$(ReleaseVersion)' -like '*-*') {
             Write-Host "##vso[task.setvariable variable=IsPreRelease;]true"
         } else {
             Write-Host "##vso[task.setvariable variable=IsPreRelease;]false"

--- a/.pipelines/templates/windows-package.yml
+++ b/.pipelines/templates/windows-package.yml
@@ -20,7 +20,7 @@ jobs:
     - group: DotNetPrivateBuildAccess
     - group: certificate_logical_to_actual
     - name: ob_sdl_sbom_enabled
-      value: false
+      value: true
     - name: ob_sdl_codeql_compiled_enabled
       value: false
     - name: ob_outputDirectory

--- a/shell/AIShell.Integration/AIShell.psm1
+++ b/shell/AIShell.Integration/AIShell.psm1
@@ -7,5 +7,10 @@ if ($null -eq $module -or $module.Version -lt [version]"2.4.2") {
     throw "The PSReadLine v2.4.2-beta2 or higher is required for the AIShell module to work properly."
 }
 
+$runspace = $Host.Runspace
+if ($null -eq $runspace) {
+    throw "Failed to import the module because '`$Host.Runspace' unexpectedly returns null.`nThe host details:`n$($Host | Out-String -Width 120)"
+}
+
 ## Create the channel singleton when loading the module.
-$null = [AIShell.Integration.Channel]::CreateSingleton($host.Runspace, [Microsoft.PowerShell.PSConsoleReadLine])
+$null = [AIShell.Integration.Channel]::CreateSingleton($runspace, [Microsoft.PowerShell.PSConsoleReadLine])

--- a/shell/AIShell.Integration/Channel.cs
+++ b/shell/AIShell.Integration/Channel.cs
@@ -31,6 +31,9 @@ public class Channel : IDisposable
 
     private Channel(Runspace runspace, Type psConsoleReadLineType)
     {
+        ArgumentNullException.ThrowIfNull(runspace);
+        ArgumentNullException.ThrowIfNull(psConsoleReadLineType);
+
         _runspace = runspace;
         _psrlType = psConsoleReadLineType;
         _connSetupWaitHandler = new ManualResetEvent(false);

--- a/shell/shell.common.props
+++ b/shell/shell.common.props
@@ -8,7 +8,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>12.0</LangVersion>
-    <Version>1.0.0-preview.3</Version>
+    <Version>1.0.0-preview.4</Version>
 
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/tools/metadata.json
+++ b/tools/metadata.json
@@ -1,3 +1,3 @@
 {
-    "AgentsToInclude": "*"
+    "AgentsToInclude": ["msaz", "openai-gpt"]
 }

--- a/tools/metadata.json
+++ b/tools/metadata.json
@@ -1,3 +1,3 @@
 {
-    "AgentsToInclude": ["msaz", "openai-gpt"]
+    "AgentsToInclude": "*"
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Merge the 1.0.0-preview.4 release branch back to main.
- Update version info for the `1.0.0-preview.4` release.
- Use deploy box and `GitHubRelease` task to create the GitHub draft release.
- Make sure the `Runspace` is available when importing the `AIShell` module and throw otherwise.
  - When validating packages, I found there were rare cases where the `Runspace` instance passed to the constructor of `AIShell.Integration.Channel` is `null`. The constructor is used only in the public static method `CreateSingleton` which is called from `AIShell.psm1` to create a singleton of the `Channel` type upon importing the `AIShell` module.
  - In `AIShell.psm1`, we call `CreateSingleton` with `$host.Runspace` to pass in the `Runspace` instance, and the module's manifest defines `PowerShellHostName = 'ConsoleHost'`, so in theory, `$host.Runspace` should never be null, but that just happened.
  - I'm guessing it could be related to the `CompletionPredictor` module loaded from my profile, which attempts to sync with the modules loaded in the default session from a separate `Runspace` -- somehow, the `Channel` singleton got created from that separate `Runspace` instead of the default session -- but I cannot prove it.
  - To address this issue, I added restricted checks in both `AIShell.psm1` and the constructor of `Channel` type, to make sure that a `Channel` singleton can be created only if the `Runspace` instance is available. Related changes are in this commit: https://github.com/PowerShell/AIShell/pull/379/commits/a447dee63ad3fa2a4a5f93d26cd049d2902999cb.


