### PR TITLE
Update `DefaultAzureCredential` to allow `InteractiveBrowserCredential`

### DIFF
--- a/shell/agents/AIShell.OpenAI.Agent/Service.cs
+++ b/shell/agents/AIShell.OpenAI.Agent/Service.cs
@@ -158,7 +158,7 @@ internal class ChatService
             }
             else
             {
-                var credential = new DefaultAzureCredential();
+                var credential = new DefaultAzureCredential(includeInteractiveCredentials: true);
 
                 var aiClient = new AzureOpenAIClient(
                     new Uri(_gptToUse.Endpoint),


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

The `InteractiveBrowserCredential` is excluded by default because it requires user's interaction.
Update `DefaultAzureCredential` to allow `InteractiveBrowserCredential`.

### PR Context

We got report that when using Entra id login, it doesn't fall back to the `InteractiveBrowserCredential`.

```
ERROR: Agent failed to generate a response: DefaultAzureCredential failed to retrieve a token from the included credentials. See the troubleshooting guide for more information.
https://aka.ms/azsdk/net/identity/defaultazurecredential/troubleshoot
- EnvironmentCredential authentication unavailable. Environment variables are not fully configured. See the troubleshooting guide for more information.
https://aka.ms/azsdk/net/identity/environmentcredential/troubleshoot
- WorkloadIdentityCredential authentication unavailable. The workload options are not fully configured. See the troubleshooting guide for more information.
https://aka.ms/azsdk/net/identity/workloadidentitycredential/troubleshoot
- ManagedIdentityCredential authentication unavailable. No response received from the managed identity endpoint.
- VisualStudioCredential authentication failed: Visual Studio Token provider can't be accessed at C:\Users\MSFTStudent\AppData\Local\.IdentityService\AzureServiceAuth\tokenprovider.json
- AzureCliCredential authentication failed: Azure CLI not installed
- AzurePowerShellCredential authentication failed: Az.Accounts module >= 2.2.0 is not installed.
- AzureDeveloperCliCredential authentication failed: Azure Developer CLI could not be found.
   at Azure.Identity.DefaultAzureCredential.GetTokenFromSourcesAsync(TokenCredential[] sources, TokenRequestContext requestContext, Boolean async, CancellationToken cancellationToken)
...
```
