### PR TITLE
Make AIShell an MCP client to expose MCP tools to its agents

### DIFF
--- a/shell/AIShell.Abstraction/AIShell.Abstraction.csproj
+++ b/shell/AIShell.Abstraction/AIShell.Abstraction.csproj
@@ -7,6 +7,6 @@
 
   <ItemGroup>
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
-    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="9.5.0" />
+    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="9.6.0" />
   </ItemGroup>
 </Project>

--- a/shell/AIShell.Abstraction/AIShell.Abstraction.csproj
+++ b/shell/AIShell.Abstraction/AIShell.Abstraction.csproj
@@ -7,5 +7,6 @@
 
   <ItemGroup>
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="9.5.0" />
   </ItemGroup>
 </Project>

--- a/shell/AIShell.Abstraction/IShell.cs
+++ b/shell/AIShell.Abstraction/IShell.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.AI;
+
 namespace AIShell.Abstraction;
 
 /// <summary>
@@ -26,6 +28,26 @@ public interface IShell
     /// <param name="text">The markdown text.</param>
     /// <returns>A list of code blocks or null if there is no code block.</returns>
     List<CodeBlock> ExtractCodeBlocks(string text, out List<SourceInfo> sourceInfos);
+
+    /// <summary>
+    /// Get available <see cref="AIFunction"/> instances for LLM to use.
+    /// </summary>
+    /// <returns></returns>
+    Task<List<AIFunction>> GetAIFunctions();
+
+    /// <summary>
+    /// Call an AI function.
+    /// </summary>
+    /// <param name="functionCall">A <see cref="FunctionCallContent"/> instance representing the function call request.</param>
+    /// <param name="captureException">Whether or not to capture the exception thrown from calling the tool.</param>
+    /// <param name="includeDetailedErrors">Whether or not to include the exception message to the message of the call result.</param>
+    /// <param name="cancellationToken">The cancellation token to cancel the call.</param>
+    /// <returns></returns>
+    Task<FunctionResultContent> CallAIFunction(
+        FunctionCallContent functionCall,
+        bool captureException,
+        bool includeDetailedErrors,
+        CancellationToken cancellationToken);
 
     // TODO:
     // - methods to run code: python, command-line, powershell, node-js.

--- a/shell/AIShell.App/AIShell.App.csproj
+++ b/shell/AIShell.App/AIShell.App.csproj
@@ -12,7 +12,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\AIShell.Kernel\AIShell.Kernel.csproj" />
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.7" />
   </ItemGroup>
 

--- a/shell/AIShell.Kernel/AIShell.Kernel.csproj
+++ b/shell/AIShell.Kernel/AIShell.Kernel.csproj
@@ -6,8 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Spectre.Console" Version="0.47.0" />
+    <PackageReference Include="Spectre.Console" Version="0.50.0" />
+    <PackageReference Include="Spectre.Console.Json" Version="0.50.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    <PackageReference Include="ModelContextProtocol.Core" Version="0.2.0-preview.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/shell/AIShell.Kernel/AIShell.Kernel.csproj
+++ b/shell/AIShell.Kernel/AIShell.Kernel.csproj
@@ -6,9 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Spectre.Console" Version="0.50.0" />
     <PackageReference Include="Spectre.Console.Json" Version="0.50.0" />
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="ModelContextProtocol.Core" Version="0.2.0-preview.3" />
   </ItemGroup>
 

--- a/shell/AIShell.Kernel/Command/CommandRunner.cs
+++ b/shell/AIShell.Kernel/Command/CommandRunner.cs
@@ -35,6 +35,7 @@ internal class CommandRunner
             new RefreshCommand(),
             new RetryCommand(),
             new HelpCommand(),
+            new McpCommand(),
             //new RenderCommand(),
         };
 

--- a/shell/AIShell.Kernel/Command/McpCommand.cs
+++ b/shell/AIShell.Kernel/Command/McpCommand.cs
@@ -1,0 +1,40 @@
+﻿using System.CommandLine;
+using AIShell.Abstraction;
+
+namespace AIShell.Kernel.Commands;
+
+internal sealed class McpCommand : CommandBase
+{
+    public McpCommand()
+        : base("mcp", "Command for managing MCP servers and tools.")
+    {
+        this.SetHandler(ShowMCPData);
+
+        //var start = new Command("start", "Start an MCP server.");
+        //var stop = new Command("stop", "Stop an MCP server.");
+        //var server = new Argument<string>(
+        //    name: "server",
+        //    getDefaultValue: () => null,
+        //    description: "Name of an MCP server.").AddCompletions(AgentCompleter);
+
+        //start.AddArgument(server);
+        //start.SetHandler(StartMcpServer, server);
+
+        //stop.AddArgument(server);
+        //stop.SetHandler(StopMcpServer, server);
+    }
+
+    private void ShowMCPData()
+    {
+        var shell = (Shell)Shell;
+        var host = shell.Host;
+
+        if (shell.McpManager.McpServers.Count is 0)
+        {
+            host.WriteErrorLine("No MCP server is available.");
+            return;
+        }
+
+        host.RenderMcpServersAndTools(shell.McpManager);
+    }
+}

--- a/shell/AIShell.Kernel/Host.cs
+++ b/shell/AIShell.Kernel/Host.cs
@@ -582,7 +582,7 @@ internal sealed class Host : IHost
 
             {tool.Description}
 
-            Input:{(hasArgs ? string.Empty : "<Empty>")}
+            Input:{(hasArgs ? string.Empty : " <none>")}
             """);
 
         if (hasArgs)
@@ -605,7 +605,9 @@ internal sealed class Host : IHost
             .Header("[green]  Tool Call Request  [/]")
             .BorderColor(Color.Grey);
 
+        ansiConsole.WriteLine();
         ansiConsole.Write(panel);
+        FancyStreamRender.ConsoleUpdated();
     }
 
     private static Spinner GetSpinner(SpinnerKind? kind)

--- a/shell/AIShell.Kernel/MCP/McpConfig.cs
+++ b/shell/AIShell.Kernel/MCP/McpConfig.cs
@@ -1,0 +1,195 @@
+﻿using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
+
+namespace AIShell.Kernel.Mcp;
+
+/// <summary>
+/// MCP configuration defined in mcp.json.
+/// </summary>
+internal class McpConfig
+{
+    [JsonPropertyName("servers")]
+    public Dictionary<string, McpServerConfig> Servers { get; set; } = [];
+
+    internal static McpConfig Load()
+    {
+        McpConfig mcpConfig = null;
+        FileInfo file = new(Utils.AppMcpFile);
+        if (file.Exists)
+        {
+            using var stream = file.OpenRead();
+            mcpConfig = JsonSerializer.Deserialize(stream, McpJsonContext.Default.McpConfig);
+            mcpConfig.Validate();
+        }
+
+        return mcpConfig is { Servers.Count: 0 } ? null : mcpConfig;
+    }
+
+    /// <summary>
+    /// Post-deserialization validation.
+    /// </summary>
+    /// <exception cref="InvalidOperationException"></exception>
+    private void Validate()
+    {
+        List<string> allErrors = null;
+
+        foreach (var (name, server) in Servers)
+        {
+            server.Name = name;
+            if (Enum.TryParse(server.Type, ignoreCase: true, out McpType mcpType))
+            {
+                server.Transport = mcpType;
+            }
+            else
+            {
+                (allErrors ??= []).Add($"Server '{name}': 'type' is required and the value should be one of the following: {string.Join(',', Enum.GetNames<McpType>())}.");
+                continue;
+            }
+
+            List<string> curErrs = null;
+
+            if (mcpType is McpType.stdio)
+            {
+                bool hasUrlGroup = !string.IsNullOrEmpty(server.Url) || server.Headers is { };
+                if (hasUrlGroup)
+                {
+                    (curErrs ??= []).Add($"'url' and 'headers' fields are invalid for 'stdio' type servers.");
+                }
+
+                if (string.IsNullOrEmpty(server.Command))
+                {
+                    (curErrs ??= []).Add($"'command' is required for 'stdio' type servers.");
+                }
+            }
+            else
+            {
+                bool hasCommandGroup = !string.IsNullOrEmpty(server.Command) || server.Args is { } || server.Env is { };
+                if (hasCommandGroup)
+                {
+                    (curErrs ??= []).Add($"'command', 'args', and 'env' fields are invalid for '{mcpType}' type servers.");
+                }
+
+                if (string.IsNullOrEmpty(server.Url))
+                {
+                    (curErrs ??= []).Add($"'url' is required for '{mcpType}' type servers.");
+                }
+                else if (!Uri.TryCreate(server.Url, UriKind.Absolute, out Uri uri))
+                {
+                    (curErrs ??= []).Add($"the specified value for 'url' is not a valid URI.");
+                }
+                else if (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps)
+                {
+                    (curErrs ??= []).Add($"'url' is expected to be a 'http' or 'https' resource.");
+                }
+                else
+                {
+                    server.Endpoint = uri;
+                }
+            }
+
+            if (curErrs is [string onlyErr])
+            {
+                (allErrors ??= []).Add($"Server '{name}': {onlyErr}");
+            }
+            else if (curErrs is { Count: > 1 })
+            {
+                string prefix = $"Server '{name}':";
+                int size = curErrs.Sum(a => a.Length) + curErrs.Count * 5 + prefix.Length;
+                StringBuilder sb = new(prefix, capacity: size);
+
+                foreach (string element in curErrs)
+                {
+                    sb.Append($"\n  - {element}");
+                }
+
+                (allErrors ??= []).Add(sb.ToString());
+            }
+        }
+
+        if (allErrors is { })
+        {
+            string errorMsg = string.Join('\n', allErrors);
+            throw new InvalidOperationException(errorMsg);
+        }
+    }
+}
+
+/// <summary>
+/// Configuration of a server.
+/// </summary>
+internal class McpServerConfig
+{
+    [JsonPropertyName("type")]
+    public string Type { get; set; }
+
+    [JsonPropertyName("command")]
+    public string Command { get; set; }
+
+    [JsonPropertyName("args")]
+    public List<string> Args { get; set; }
+
+    [JsonPropertyName("env")]
+    public Dictionary<string, string> Env { get; set; }
+
+    [JsonPropertyName("url")]
+    public string Url { get; set; }
+
+    [JsonPropertyName("headers")]
+    public Dictionary<string, string> Headers { get; set; }
+
+    internal string Name { get; set; }
+    internal Uri Endpoint { get; set; }
+    internal McpType Transport { get; set; }
+
+    internal IClientTransport ToClientTransport()
+    {
+        return Transport switch
+        {
+            McpType.stdio => new StdioClientTransport(new()
+            {
+                Name = Name,
+                Command = Command,
+                Arguments = Args,
+                EnvironmentVariables = Env,
+            }),
+
+            _ => new SseClientTransport(new()
+            {
+                Name = Name,
+                Endpoint = Endpoint,
+                AdditionalHeaders = Headers,
+                TransportMode = Transport is McpType.sse ? HttpTransportMode.Sse : HttpTransportMode.StreamableHttp,
+                ConnectionTimeout = TimeSpan.FromSeconds(15),
+            })
+        };
+    }
+}
+
+/// <summary>
+/// MCP transport types.
+/// </summary>
+internal enum McpType
+{
+    stdio,
+    sse,
+    http,
+}
+
+/// <summary>
+/// Source generation helper for deserializing mcp.json.
+/// </summary>
+[JsonSourceGenerationOptions(
+    WriteIndented = true,
+    AllowTrailingCommas = true,
+    PropertyNameCaseInsensitive = true,
+    ReadCommentHandling = JsonCommentHandling.Skip,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    UseStringEnumConverter = true)]
+[JsonSerializable(typeof(McpConfig))]
+[JsonSerializable(typeof(McpServerConfig))]
+[JsonSerializable(typeof(CallToolResponse))]
+internal partial class McpJsonContext : JsonSerializerContext { }

--- a/shell/AIShell.Kernel/MCP/McpManager.cs
+++ b/shell/AIShell.Kernel/MCP/McpManager.cs
@@ -1,0 +1,161 @@
+﻿
+using Microsoft.Extensions.AI;
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
+
+namespace AIShell.Kernel.Mcp;
+
+internal class McpManager
+{
+    private readonly McpServerInitContext _context;
+    private readonly Dictionary<string, McpServer> _mcpServers;
+
+    private readonly Task _initTask;
+    private readonly TaskCompletionSource<McpConfig> _parseMcpJsonTaskSource;
+
+    private McpConfig _mcpConfig;
+
+    internal Task<McpConfig> ParseMcpJsonTask => _parseMcpJsonTaskSource.Task;
+
+    internal McpManager(Shell shell)
+    {
+        _context = new(shell);
+        _parseMcpJsonTaskSource = new();
+        _mcpServers = new(StringComparer.OrdinalIgnoreCase);
+
+        _initTask = Task.Run(Initialize);
+    }
+
+    private void Initialize()
+    {
+        try
+        {
+            _mcpConfig = McpConfig.Load();
+            _parseMcpJsonTaskSource.SetResult(_mcpConfig);
+        }
+        catch (Exception e)
+        {
+            _parseMcpJsonTaskSource.SetException(e);
+        }
+
+        if (_mcpConfig is null)
+        {
+            return;
+        }
+
+        foreach (var (name, config) in _mcpConfig.Servers)
+        {
+            _mcpServers.Add(name, new McpServer(config, _context));
+        }
+    }
+
+    /// <summary>
+    /// Lists tools that are available at the time of the call.
+    /// Servers that are still initializing or failed will be skipped.
+    /// </summary>
+    internal async Task<List<McpTool>> ListAvailableTools()
+    {
+        await _initTask;
+
+        List<McpTool> tools = null;
+        foreach (var (name, server) in _mcpServers)
+        {
+            if (server.IsOperational)
+            {
+                (tools ??= []).AddRange(server.Tools.Values);
+            }
+        }
+
+        return tools;
+    }
+
+    /// <summary>
+    /// Make a tool call using the given function call data.
+    /// </summary>
+    /// <param name="functionCall">The function call request.</param>
+    /// <param name="captureException">Whether or not to capture the exception thrown from calling the tool.</param>
+    /// <param name="includeDetailedErrors">Whether or not to include the exception message to the message of the call result.</param>
+    /// <param name="cancellationToken">The cancellation token to cancel the call.</param>
+    /// <returns></returns>
+    internal async Task<FunctionResultContent> CallToolAsync(
+        FunctionCallContent functionCall,
+        bool captureException = false,
+        bool includeDetailedErrors = false,
+        CancellationToken cancellationToken = default)
+    {
+        string serverName = null, toolName = null;
+
+        string functionName = functionCall.Name;
+        int dotIndex = functionName.IndexOf('.');
+        if (dotIndex > 0)
+        {
+            serverName = functionName[..dotIndex];
+            toolName = functionName[(dotIndex + 1)..];
+        }
+
+        await _initTask;
+
+        McpTool tool = null;
+        if (!string.IsNullOrEmpty(serverName)
+            && !string.IsNullOrEmpty(toolName)
+            && _mcpServers.TryGetValue(serverName, out McpServer server))
+        {
+            await server.WaitForInitAsync(cancellationToken);
+            server.Tools.TryGetValue(toolName, out tool);
+        }
+
+        if (tool is null)
+        {
+            return new FunctionResultContent(
+                functionCall.CallId,
+                $"Error: Requested function \"{functionName}\" not found.");
+        }
+
+        FunctionResultContent resultContent = new(functionCall.CallId, result: null);
+
+        try
+        {
+            CallToolResponse response = await tool.CallAsync(
+                new AIFunctionArguments(arguments: functionCall.Arguments),
+                cancellationToken: cancellationToken);
+
+            resultContent.Result = (object)response ?? "Success: Function completed.";
+        }
+        catch (Exception e) when (!cancellationToken.IsCancellationRequested)
+        {
+            if (!captureException)
+            {
+                throw;
+            }
+
+            string message = "Error: Function failed.";
+            resultContent.Exception = e;
+            resultContent.Result = includeDetailedErrors ? $"{message} Exception: {e.Message}" : message;
+        }
+
+        return resultContent;
+    }
+}
+
+internal class McpServerInitContext
+{
+    /// <summary>
+    /// The throttle limit defines the maximum number of servers that can be initiated concurrently.
+    /// </summary>
+    private const int ThrottleLimit = 5;
+
+    internal McpServerInitContext(Shell shell)
+    {
+        Shell = shell;
+        ThrottleSemaphore = new SemaphoreSlim(ThrottleLimit, ThrottleLimit);
+        ClientOptions = new()
+        {
+            ClientInfo = new() { Name = "AIShell", Version = shell.Version },
+            InitializationTimeout = TimeSpan.FromSeconds(30),
+        };
+    }
+
+    internal Shell Shell { get; }
+    internal SemaphoreSlim ThrottleSemaphore { get; }
+    internal McpClientOptions ClientOptions { get; }
+}

--- a/shell/AIShell.Kernel/MCP/McpManager.cs
+++ b/shell/AIShell.Kernel/MCP/McpManager.cs
@@ -1,5 +1,4 @@
-﻿
-using Microsoft.Extensions.AI;
+﻿using Microsoft.Extensions.AI;
 using ModelContextProtocol.Client;
 using ModelContextProtocol.Protocol;
 
@@ -53,11 +52,11 @@ internal class McpManager
     /// Lists tools that are available at the time of the call.
     /// Servers that are still initializing or failed will be skipped.
     /// </summary>
-    internal async Task<List<McpTool>> ListAvailableTools()
+    internal async Task<List<AIFunction>> ListAvailableTools()
     {
         await _initTask;
 
-        List<McpTool> tools = null;
+        List<AIFunction> tools = null;
         foreach (var (name, server) in _mcpServers)
         {
             if (server.IsOperational)
@@ -86,7 +85,7 @@ internal class McpManager
         string serverName = null, toolName = null;
 
         string functionName = functionCall.Name;
-        int dotIndex = functionName.IndexOf('.');
+        int dotIndex = functionName.IndexOf(McpTool.ServerToolSeparator);
         if (dotIndex > 0)
         {
             serverName = functionName[..dotIndex];

--- a/shell/AIShell.Kernel/MCP/McpManager.cs
+++ b/shell/AIShell.Kernel/MCP/McpManager.cs
@@ -6,15 +6,23 @@ namespace AIShell.Kernel.Mcp;
 
 internal class McpManager
 {
+    private readonly Task _initTask;
     private readonly McpServerInitContext _context;
     private readonly Dictionary<string, McpServer> _mcpServers;
-
-    private readonly Task _initTask;
     private readonly TaskCompletionSource<McpConfig> _parseMcpJsonTaskSource;
 
     private McpConfig _mcpConfig;
 
     internal Task<McpConfig> ParseMcpJsonTask => _parseMcpJsonTaskSource.Task;
+
+    internal Dictionary<string, McpServer> McpServers
+    {
+        get
+        {
+            _initTask.Wait();
+            return _mcpServers;
+        }
+    }
 
     internal McpManager(Shell shell)
     {

--- a/shell/AIShell.Kernel/MCP/McpServer.cs
+++ b/shell/AIShell.Kernel/MCP/McpServer.cs
@@ -1,0 +1,132 @@
+﻿using ModelContextProtocol.Client;
+
+namespace AIShell.Kernel.Mcp;
+
+internal class McpServer : IDisposable
+{
+    private readonly McpServerConfig _config;
+    private readonly McpServerInitContext _context;
+    private readonly Dictionary<string, McpTool> _tools;
+    private readonly Task _initTask;
+
+    private string _serverInfo;
+    private IMcpClient _client;
+    private Exception _error;
+
+    /// <summary>
+    /// Name of the server declared in mcp.json.
+    /// </summary>
+    internal string Name => _config.Name;
+
+    /// <summary>
+    /// Gets whether the initialization is done.
+    /// </summary>
+    internal bool IsInitFinished => _initTask.IsCompleted;
+
+    /// <summary>
+    /// Gets whether the server is operational.
+    /// </summary>
+    internal bool IsOperational => _initTask.IsCompleted && _error is null;
+
+    /// <summary>
+    /// Full name and version of the server.
+    /// </summary>
+    internal string ServerInfo
+    {
+        get
+        {
+            WaitForInit();
+            return _serverInfo;
+        }
+    }
+
+    /// <summary>
+    /// The client connected to the server.
+    /// </summary>
+    internal IMcpClient Client
+    {
+        get
+        {
+            WaitForInit();
+            return _client;
+        }
+    }
+
+    /// <summary>
+    /// Exposed tools from the server.
+    /// </summary>
+    internal Dictionary<string, McpTool> Tools
+    {
+        get
+        {
+            WaitForInit();
+            return _tools;
+        }
+    }
+
+    internal Exception Error
+    {
+        get
+        {
+            WaitForInit();
+            return _error;
+        }
+    }
+
+    internal McpServer(McpServerConfig config, McpServerInitContext context)
+    {
+        _config = config;
+        _context = context;
+        _tools = new(StringComparer.OrdinalIgnoreCase);
+        _initTask = Initialize();
+    }
+
+    private async Task Initialize()
+    {
+        try
+        {
+            await _context.ThrottleSemaphore.WaitAsync();
+
+            IClientTransport transport = _config.ToClientTransport();
+            _client = await McpClientFactory.CreateAsync(transport, _context.ClientOptions);
+
+            var serverInfo = _client.ServerInfo;
+            _serverInfo = $"{serverInfo.Name} {serverInfo.Version}";
+
+            await foreach (McpClientTool tool in _client.EnumerateToolsAsync())
+            {
+                _tools.TryAdd(tool.Name, new McpTool(Name, tool, _context.Shell.Host));
+            }
+        }
+        catch (Exception e)
+        {
+            _error = e;
+            _tools.Clear();
+            if (_client is { })
+            {
+                await _client.DisposeAsync();
+                _client = null;
+            }
+        }
+        finally
+        {
+            _context.ThrottleSemaphore.Release();
+        }
+    }
+
+    internal void WaitForInit(CancellationToken cancellationToken = default)
+    {
+        _initTask.Wait(cancellationToken);
+    }
+
+    internal async Task WaitForInitAsync(CancellationToken cancellationToken = default)
+    {
+        await _initTask.WaitAsync(cancellationToken);
+    }
+
+    public void Dispose()
+    {
+        _tools.Clear();
+        _client?.DisposeAsync().AsTask().Wait();
+    }
+}

--- a/shell/AIShell.Kernel/MCP/McpServer.cs
+++ b/shell/AIShell.Kernel/MCP/McpServer.cs
@@ -91,7 +91,10 @@ internal class McpServer : IDisposable
             _client = await McpClientFactory.CreateAsync(transport, _context.ClientOptions);
 
             var serverInfo = _client.ServerInfo;
-            _serverInfo = $"{serverInfo.Name} {serverInfo.Version}";
+            // An MCP server may have the name included in the version info.
+            _serverInfo = serverInfo.Version.Contains(serverInfo.Name, StringComparison.OrdinalIgnoreCase)
+                ? serverInfo.Version
+                : $"{serverInfo.Name} {serverInfo.Version}";
 
             await foreach (McpClientTool tool in _client.EnumerateToolsAsync())
             {

--- a/shell/AIShell.Kernel/MCP/McpTool.cs
+++ b/shell/AIShell.Kernel/MCP/McpTool.cs
@@ -18,11 +18,13 @@ internal class McpTool : AIFunction
     private readonly McpClientTool _clientTool;
     private readonly string[] _userChoices;
 
+    internal const string ServerToolSeparator = "___";
+
     internal McpTool(string serverName, McpClientTool clientTool, Host host)
     {
         _host = host;
         _clientTool = clientTool;
-        _fullName = $"{serverName}.{clientTool.Name}";
+        _fullName = $"{serverName}{ServerToolSeparator}{clientTool.Name}";
         _serverName = serverName;
         _userChoices = ["Continue", "Cancel"];
     }
@@ -112,7 +114,7 @@ internal class McpTool : AIFunction
         _host.RenderToolCallRequest(this, jsonArgs);
 
         // Prompt for user's approval to call the tool.
-        const string title = "\n⚠️ MCP servers or malicious converstaion content may attempt to misuse 'AIShell' through the installed tools. Please carefully review any requested actions. Do you want to proceed with the call?";
+        const string title = "\n⚠️ MCP servers or malicious converstaion content may attempt to misuse 'AIShell' through the installed tools. Please carefully review any requested actions to decide if you want to proceed.";
         string choice = await _host.PromptForSelectionAsync(
             title: title,
             choices: _userChoices,
@@ -129,7 +131,7 @@ internal class McpTool : AIFunction
             status: $"Running '{OriginalName}'",
             spinnerKind: SpinnerKind.Processing);
 
-        _host.WriteLine($"\n    [green]\u2713[/] Ran '{OriginalName}'\n");
+        _host.MarkupLine($"\n    [green]\u2713[/] Ran '{OriginalName}'");
         return response;
     }
 }

--- a/shell/AIShell.Kernel/MCP/McpTool.cs
+++ b/shell/AIShell.Kernel/MCP/McpTool.cs
@@ -122,7 +122,7 @@ internal class McpTool : AIFunction
 
         if (choice is "Cancel")
         {
-            _host.MarkupLine($"\n    [red]\u2717[/] Cancelled '{OriginalName}'\n");
+            _host.MarkupLine($"\n    [red]\u2717[/] Cancelled '{OriginalName}'");
             throw new OperationCanceledException("The call was rejected by user.");
         }
 

--- a/shell/AIShell.Kernel/MCP/McpTool.cs
+++ b/shell/AIShell.Kernel/MCP/McpTool.cs
@@ -1,0 +1,135 @@
+﻿using System.Text.Json;
+using AIShell.Abstraction;
+using Microsoft.Extensions.AI;
+using ModelContextProtocol;
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
+
+namespace AIShell.Kernel.Mcp;
+
+/// <summary>
+/// A wrapper class of <see cref="McpClientTool"/> to make sure the call to the tool always go through the AIShell.
+/// </summary>
+internal class McpTool : AIFunction
+{
+    private readonly string _fullName;
+    private readonly string _serverName;
+    private readonly Host _host;
+    private readonly McpClientTool _clientTool;
+    private readonly string[] _userChoices;
+
+    internal McpTool(string serverName, McpClientTool clientTool, Host host)
+    {
+        _host = host;
+        _clientTool = clientTool;
+        _fullName = $"{serverName}.{clientTool.Name}";
+        _serverName = serverName;
+        _userChoices = ["Continue", "Cancel"];
+    }
+
+    /// <summary>
+    /// The server name for this tool.
+    /// </summary>
+    internal string ServerName => _serverName;
+
+    /// <summary>
+    /// The original tool name without the server name prefix.
+    /// </summary>
+    internal string OriginalName => _clientTool.Name;
+
+    /// <summary>
+    /// The fully qualified name of the tool in the form of '<server-name>.<tool-name>'
+    /// </summary>
+    public override string Name => _fullName;
+
+    /// <inheritdoc />
+    public override string Description => _clientTool.Description;
+
+    /// <inheritdoc />
+    public override JsonElement JsonSchema => _clientTool.JsonSchema;
+
+    /// <inheritdoc />
+    public override JsonSerializerOptions JsonSerializerOptions => _clientTool.JsonSerializerOptions;
+
+    /// <inheritdoc />
+    public override IReadOnlyDictionary<string, object> AdditionalProperties => _clientTool.AdditionalProperties;
+
+    /// <summary>
+    /// Overrides the base method with the call to <see cref="CallAsync"/>. The only difference in behavior is we will serialize
+    /// the resulting <see cref="CallToolResponse"/> such that the <see cref="object" /> returned is a <see cref="JsonElement" />
+    /// containing the serialized <see cref="CallToolResponse" />. This method is intended to be used polymorphically via the base
+    /// class, typically as part of an <see cref="IChatClient" /> operation.
+    /// </summary>
+    protected override async ValueTask<object> InvokeCoreAsync(AIFunctionArguments arguments, CancellationToken cancellationToken)
+    {
+        return JsonSerializer.SerializeToElement(
+            await CallAsync(
+                arguments,
+                progress: null,
+                JsonSerializerOptions,
+                cancellationToken).ConfigureAwait(false),
+            McpJsonContext.Default.CallToolResponse);
+    }
+
+    /// <summary>
+    /// Invokes the tool on the server if the user approves.
+    /// </summary>
+    /// <param name="arguments">
+    /// An optional dictionary of arguments to pass to the tool.
+    /// Each key represents a parameter name, and its associated value represents the argument value.
+    /// </param>
+    /// <param name="progress">
+    /// An optional <see cref="IProgress{T}" /> to have progress notifications reported to it.
+    /// Setting this to a non-<see langword="null" /> value will result in a progress token being included in the call,
+    /// and any resulting progress notifications during the operation routed to this instance.
+    /// </param>
+    /// <param name="serializerOptions">
+    /// The JSON serialization options governing argument serialization.
+    /// If <see langword="null" />, the default serialization options will be used.
+    /// </param>
+    /// <param name="cancellationToken">
+    /// The cancellation token to monitor for cancellation requests.
+    /// The default is <see cref="CancellationToken.None" />.
+    /// </param>
+    /// <returns>
+    /// A task containing the response from the tool execution. The response includes the tool's output content, which may be structured data, text, or an error message.
+    /// </returns>
+    /// <remarks>
+    /// This method wraps the <see cref="McpClientTool.CallAsync"/> method to add the user interactions for displaying the too call request and prompting the user for approval.
+    /// </remarks>
+    /// <exception cref="OperationCanceledException">The user rejected the tool call.</exception>
+    /// <exception cref="McpException">The server could not find the requested tool, or the server encountered an error while processing the request.</exception>
+    internal async ValueTask<CallToolResponse> CallAsync(
+        IReadOnlyDictionary<string, object> arguments = null,
+        IProgress<ProgressNotificationValue> progress = null,
+        JsonSerializerOptions serializerOptions = null,
+        CancellationToken cancellationToken = default)
+    {
+        // Display the tool call request.
+        string jsonArgs = arguments is { Count: > 0 }
+            ? JsonSerializer.Serialize(arguments, serializerOptions ?? JsonSerializerOptions)
+            : null;
+        _host.RenderToolCallRequest(this, jsonArgs);
+
+        // Prompt for user's approval to call the tool.
+        const string title = "\n⚠️ MCP servers or malicious converstaion content may attempt to misuse 'AIShell' through the installed tools. Please carefully review any requested actions. Do you want to proceed with the call?";
+        string choice = await _host.PromptForSelectionAsync(
+            title: title,
+            choices: _userChoices,
+            cancellationToken: cancellationToken);
+
+        if (choice is "Cancel")
+        {
+            _host.MarkupLine($"\n    [red]\u2717[/] Cancelled '{OriginalName}'\n");
+            throw new OperationCanceledException("The call was rejected by user.");
+        }
+
+        CallToolResponse response = await _host.RunWithSpinnerAsync(
+            async () => await _clientTool.CallAsync(arguments, progress, serializerOptions, cancellationToken),
+            status: $"Running '{OriginalName}'",
+            spinnerKind: SpinnerKind.Processing);
+
+        _host.WriteLine($"\n    [green]\u2713[/] Ran '{OriginalName}'\n");
+        return response;
+    }
+}

--- a/shell/AIShell.Kernel/MCP/McpTool.cs
+++ b/shell/AIShell.Kernel/MCP/McpTool.cs
@@ -114,7 +114,7 @@ internal class McpTool : AIFunction
         _host.RenderToolCallRequest(this, jsonArgs);
 
         // Prompt for user's approval to call the tool.
-        const string title = "\n⚠️ MCP servers or malicious converstaion content may attempt to misuse 'AIShell' through the installed tools. Please carefully review any requested actions to decide if you want to proceed.";
+        const string title = "\n\u26A0  MCP servers or malicious converstaion content may attempt to misuse 'AIShell' through the installed tools. Please carefully review any requested actions to decide if you want to proceed.";
         string choice = await _host.PromptForSelectionAsync(
             title: title,
             choices: _userChoices,

--- a/shell/AIShell.Kernel/Setting.cs
+++ b/shell/AIShell.Kernel/Setting.cs
@@ -19,7 +19,7 @@ internal class Setting
             try
             {
                 using var stream = file.OpenRead();
-                return JsonSerializer.Deserialize(stream, SourceGenerationContext.Default.Setting);
+                return JsonSerializer.Deserialize(stream, AppSettingJsonContext.Default.Setting);
             }
             catch (Exception e)
             {
@@ -48,4 +48,4 @@ internal class Setting
     ReadCommentHandling = JsonCommentHandling.Skip,
     UseStringEnumConverter = true)]
 [JsonSerializable(typeof(Setting))]
-internal partial class SourceGenerationContext : JsonSerializerContext { }
+internal partial class AppSettingJsonContext : JsonSerializerContext { }

--- a/shell/AIShell.Kernel/Shell.cs
+++ b/shell/AIShell.Kernel/Shell.cs
@@ -1,7 +1,9 @@
 using System.Reflection;
-using Microsoft.PowerShell;
 using AIShell.Abstraction;
 using AIShell.Kernel.Commands;
+using AIShell.Kernel.Mcp;
+using Microsoft.Extensions.AI;
+using Microsoft.PowerShell;
 using Spectre.Console;
 
 namespace AIShell.Kernel;
@@ -14,6 +16,7 @@ internal sealed class Shell : IShell
     private readonly ShellWrapper _wrapper;
     private readonly HashSet<string> _textToIgnore;
     private readonly Setting _setting;
+    private readonly McpManager _mcpManager;
 
     private bool _shouldRefresh;
     private LLMAgent _activeAgent;
@@ -85,6 +88,9 @@ internal sealed class Shell : IShell
     bool IShell.ChannelEstablished => Channel is not null;
     CancellationToken IShell.CancellationToken => _cancellationSource.Token;
     List<CodeBlock> IShell.ExtractCodeBlocks(string text, out List<SourceInfo> sourceInfos) => Utils.ExtractCodeBlocks(text, out sourceInfos);
+    async Task<List<AIFunction>> IShell.GetAIFunctions() => await _mcpManager.ListAvailableTools();
+    async Task<FunctionResultContent> IShell.CallAIFunction(FunctionCallContent functionCall, bool captureException, bool includeDetailedErrors, CancellationToken cancellationToken)
+        => await _mcpManager.CallToolAsync(functionCall, captureException, includeDetailedErrors, cancellationToken);
 
     #endregion IShell implementation
 
@@ -109,6 +115,7 @@ internal sealed class Shell : IShell
         _textToIgnore = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         _cancellationSource = new CancellationTokenSource();
         _version = typeof(Shell).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
+        _mcpManager = new(this);
 
         Exit = false;
         Regenerate = false;
@@ -161,9 +168,21 @@ internal sealed class Shell : IShell
             _activeAgent.Display(Host, isWrapped ? _wrapper.Description : null);
         }
 
+        try
+        {
+            McpConfig config = _mcpManager.ParseMcpJsonTask.GetAwaiter().GetResult();
+            if (config is { Servers.Count: > 0 })
+            {
+                Host.MarkupNoteLine($"{config.Servers.Count} MCP server(s) configured. Run {Formatter.Command("/mcp")} for details.");
+            }
+        }
+        catch (Exception e)
+        {
+            Host.WriteErrorLine($"Failed to load the 'mcp.json' file:\n{e.Message}\nRun '/mcp config' to open the 'mcp.json' file.\n");
+        }
+
         // Write out help.
-        Host.MarkupLine($"Run {Formatter.Command("/help")} for more instructions.")
-            .WriteLine();
+        Host.MarkupLine($"Run {Formatter.Command("/help")} for more instructions.\n");
     }
 
     /// <summary>

--- a/shell/AIShell.Kernel/Shell.cs
+++ b/shell/AIShell.Kernel/Shell.cs
@@ -82,6 +82,11 @@ internal sealed class Shell : IShell
     /// </summary>
     internal string Version => _version;
 
+    /// <summary>
+    /// Gets the MCP manager.
+    /// </summary>
+    internal McpManager McpManager => _mcpManager;
+
     #region IShell implementation
 
     IHost IShell.Host => Host;

--- a/shell/AIShell.Kernel/Shell.cs
+++ b/shell/AIShell.Kernel/Shell.cs
@@ -74,6 +74,11 @@ internal sealed class Shell : IShell
     /// </summary>
     internal LLMAgent ActiveAgent => _activeAgent;
 
+    /// <summary>
+    /// Gets the version from the assembly attribute.
+    /// </summary>
+    internal string Version => _version;
+
     #region IShell implementation
 
     IHost IShell.Host => Host;

--- a/shell/AIShell.Kernel/Utility/LoadContext.cs
+++ b/shell/AIShell.Kernel/Utility/LoadContext.cs
@@ -25,7 +25,14 @@ internal class AgentAssemblyLoadContext : AssemblyLoadContext
         _dependencyDir = dependencyDir;
         _runtimeLibDir = [];
         _runtimeNativeDir = [];
-        _cache = [];
+        _cache = new()
+        {
+            // Contracts exposed from 'AIShell.Abstraction' depend on these assemblies,
+            // so agents have to depend on the same assemblies from the default ALC.
+            // Otherwise, the contracts will break due to mis-match type identities.
+            ["System.CommandLine"] = null,
+            ["Microsoft.Extensions.AI.Abstractions"] = null,
+        };
 
         if (OperatingSystem.IsWindows())
         {

--- a/shell/AIShell.Kernel/Utility/Utils.cs
+++ b/shell/AIShell.Kernel/Utility/Utils.cs
@@ -46,6 +46,7 @@ internal static class Utils
     internal static string ConfigHome;
     internal static string AppCacheDir;
     internal static string AppConfigFile;
+    internal static string AppMcpFile;
     internal static string AgentHome;
     internal static string AgentConfigHome;
 
@@ -59,6 +60,7 @@ internal static class Utils
         ConfigHome = Path.Combine(locationPath, $".{AppName.Replace(' ', '-')}");
         AppCacheDir = Path.Combine(ConfigHome, ".cache");
         AppConfigFile = Path.Combine(ConfigHome, "config.json");
+        AppMcpFile = Path.Combine(ConfigHome, "mcp.json");
         AgentHome = Path.Join(ConfigHome, "agents");
         AgentConfigHome = Path.Join(ConfigHome, "agent-config");
 

--- a/shell/Markdown.VT/Markdown.VT.csproj
+++ b/shell/Markdown.VT/Markdown.VT.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Markdig" Version="0.31.0" />
+    <PackageReference Include="Markdig" Version="0.41.2" />
     <PackageReference Include="ColorCode.Core" Version="2.0.15" />
-    <PackageReference Include="Spectre.Console" Version="0.47.0" />
+    <PackageReference Include="Spectre.Console" Version="0.50.0" />
   </ItemGroup>
 
 </Project>

--- a/shell/agents/AIShell.Ollama.Agent/AIShell.Ollama.Agent.csproj
+++ b/shell/agents/AIShell.Ollama.Agent/AIShell.Ollama.Agent.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OllamaSharp" Version="4.0.8" />
+    <PackageReference Include="OllamaSharp" Version="5.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/shell/agents/AIShell.OpenAI.Agent/AIShell.OpenAI.Agent.csproj
+++ b/shell/agents/AIShell.OpenAI.Agent/AIShell.OpenAI.Agent.csproj
@@ -21,11 +21,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.AI.OpenAI" Version="2.1.0" />
-    <PackageReference Include="Azure.Identity" Version="1.13.2" />
-    <PackageReference Include="Microsoft.ML.Tokenizers" Version="1.0.1" />
-    <PackageReference Include="Microsoft.ML.Tokenizers.Data.O200kBase" Version="1.0.1" />
-    <PackageReference Include="Microsoft.ML.Tokenizers.Data.Cl100kBase" Version="1.0.1" />
+    <PackageReference Include="Azure.AI.OpenAI" Version="2.2.0-beta.4" />
+    <PackageReference Include="Azure.Identity" Version="1.14.0" />
+    <PackageReference Include="Microsoft.Extensions.AI" Version="9.6.0" />
+    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="9.6.0-preview.1.25310.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/shell/agents/AIShell.OpenAI.Agent/ModelInfo.cs
+++ b/shell/agents/AIShell.OpenAI.Agent/ModelInfo.cs
@@ -1,5 +1,3 @@
-using Microsoft.ML.Tokenizers;
-
 namespace AIShell.OpenAI.Agent;
 
 internal class ModelInfo
@@ -11,7 +9,6 @@ internal class ModelInfo
     private const string Gpt34Encoding = "cl100k_base";
 
     private static readonly Dictionary<string, ModelInfo> s_modelMap;
-    private static readonly Dictionary<string, Task<Tokenizer>> s_encodingMap;
 
     // A rough estimate to cover all third-party models.
     //  - most popular models today support 32K+ context length;
@@ -37,21 +34,12 @@ internal class ModelInfo
             // Azure naming of the 'gpt-3.5-turbo' models
             ["gpt-35-turbo"]  = new(tokenLimit: 16_385),
         };
-
-        // The first call to 'GptEncoding.GetEncoding' is very slow, taking about 2 seconds on my machine.
-        // We don't immediately need the encodings at the startup, so by getting the values in tasks,
-        // we don't block the startup and the values will be ready when we really need them.
-        s_encodingMap = new(StringComparer.OrdinalIgnoreCase)
-        {
-            [Gpt34Encoding] = Task.Run(() => (Tokenizer)TiktokenTokenizer.CreateForEncoding(Gpt34Encoding)),
-            [Gpt4oEncoding] = Task.Run(() => (Tokenizer)TiktokenTokenizer.CreateForEncoding(Gpt4oEncoding))
-        };
     }
 
     private ModelInfo(int tokenLimit, string encoding = null, bool reasoning = false)
     {
         TokenLimit = tokenLimit;
-        _encodingName = encoding ?? Gpt34Encoding;
+        EncodingName = encoding ?? Gpt34Encoding;
 
         // For gpt4o, gpt4 and gpt3.5-turbo, the following 2 properties are the same.
         // See https://github.com/openai/openai-cookbook/blob/main/examples/How_to_count_tokens_with_tiktoken.ipynb
@@ -60,22 +48,11 @@ internal class ModelInfo
         Reasoning = reasoning;
     }
 
-    private readonly string _encodingName;
-    private Tokenizer _gptEncoding;
-
+    internal string EncodingName { get; }
     internal int TokenLimit { get; }
     internal int TokensPerMessage { get; }
     internal int TokensPerName { get; }
     internal bool Reasoning { get; }
-    internal Tokenizer Encoding
-    {
-        get {
-            _gptEncoding ??= s_encodingMap.TryGetValue(_encodingName, out Task<Tokenizer> value)
-                ? value.Result
-                : TiktokenTokenizer.CreateForEncoding(_encodingName);
-            return _gptEncoding;
-        }
-    }
 
     /// <summary>
     /// Try resolving the specified model name.

--- a/shell/agents/AIShell.OpenAI.Agent/Service.cs
+++ b/shell/agents/AIShell.OpenAI.Agent/Service.cs
@@ -127,18 +127,27 @@ internal class ChatService
 
         _client = client.AsIChatClient()
             .AsBuilder()
-            .UseFunctionInvocation()
+            .UseFunctionInvocation(configure: c => c.IncludeDetailedErrors = true)
             .Build();
     }
 
     private void PrepareForChat(string input)
     {
+        const string Guidelines = """
+            ## Tool Use Guidelines
+            You may have access to external tools.
+            Before making any tool call, you must first explain the reason for using the tool. Only issue the tool call after providing this explanation.
+
+            ## Other Guidelines
+            """;
+
         // Refresh the client in case the active model was changed.
         RefreshOpenAIClient();
 
         if (_chatHistory.Count is 0)
         {
-            _chatHistory.Add(new(ChatRole.System, _gptToUse.SystemPrompt));
+            string system = $"{Guidelines}\n{_gptToUse.SystemPrompt}";
+            _chatHistory.Add(new(ChatRole.System, system));
         }
 
         _chatHistory.Add(new(ChatRole.User, input));

--- a/shell/agents/AIShell.OpenAI.Agent/Service.cs
+++ b/shell/agents/AIShell.OpenAI.Agent/Service.cs
@@ -1,102 +1,45 @@
 using System.ClientModel;
 using System.ClientModel.Primitives;
 using Azure.AI.OpenAI;
-using Azure.Core;
 using Azure.Identity;
-using Microsoft.ML.Tokenizers;
+using Microsoft.Extensions.AI;
 using OpenAI;
-using OpenAI.Chat;
+
+using OpenAIChatClient = OpenAI.Chat.ChatClient;
+using ChatMessage = Microsoft.Extensions.AI.ChatMessage;
+using AIShell.Abstraction;
 
 namespace AIShell.OpenAI.Agent;
 
 internal class ChatService
 {
     // TODO: Maybe expose this to our model registration?
-    // We can still use 1000 as the default value.
-    private const int MaxResponseToken = 2000;
+    private const int MaxResponseToken = 1000;
     private readonly string _historyRoot;
     private readonly List<ChatMessage> _chatHistory;
-    private readonly List<int> _chatHistoryTokens;
-    private readonly ChatCompletionOptions _chatOptions;
+    private readonly ChatOptions _chatOptions;
 
     private GPT _gptToUse;
     private Settings _settings;
-    private ChatClient _client;
-    private int _totalInputToken;
+    private IChatClient _client;
 
     internal ChatService(string historyRoot, Settings settings)
     {
         _chatHistory = [];
-        _chatHistoryTokens = [];
         _historyRoot = historyRoot;
-
-        _totalInputToken = 0;
         _settings = settings;
 
-        _chatOptions = new ChatCompletionOptions()
+        _chatOptions = new ChatOptions()
         {
-            MaxOutputTokenCount = MaxResponseToken,
+            MaxOutputTokens = MaxResponseToken,
         };
     }
 
     internal List<ChatMessage> ChatHistory => _chatHistory;
 
-    internal void AddResponseToHistory(string response)
-    {
-        if (string.IsNullOrEmpty(response))
-        {
-            return;
-        }
-
-        _chatHistory.Add(ChatMessage.CreateAssistantMessage(response));
-    }
-
     internal void RefreshSettings(Settings settings)
     {
         _settings = settings;
-    }
-
-    /// <summary>
-    /// It's almost impossible to relative-accurately calculate the token counts of all
-    /// messages, especially when tool calls are involved (tool call definitions and the
-    /// tool call payloads in AI response).
-    /// So, I decide to leverage the useage report from AI to track the token count of
-    /// the chat history. It's also an estimate, but I think more accurate than doing the
-    /// counting by ourselves.
-    /// </summary>
-    internal void CalibrateChatHistory(ChatTokenUsage usage, AssistantChatMessage response)
-    {
-        if (usage is null)
-        {
-            // Response was cancelled and we will remove the last query from history.
-            int index = _chatHistory.Count - 1;
-            _chatHistory.RemoveAt(index);
-            _chatHistoryTokens.RemoveAt(index);
-
-            return;
-        }
-
-        // Every reply is primed with <|start|>assistant<|message|>, so we subtract 3 from the 'InputTokenCount'.
-        int promptTokenCount = usage.InputTokenCount - 3;
-        // 'ReasoningTokenCount' should be 0 for non-o1 models.
-        int reasoningTokenCount = usage.OutputTokenDetails is null ? 0 : usage.OutputTokenDetails.ReasoningTokenCount;
-        int responseTokenCount = usage.OutputTokenCount - reasoningTokenCount;
-
-        if (_totalInputToken is 0)
-        {
-            // It was the first user message, so instead of adjusting the user message token count,
-            // we set the token count for system message and tool calls.
-            _chatHistoryTokens[0] = promptTokenCount - _chatHistoryTokens[^1];
-        }
-        else
-        {
-            // Adjust the token count of the user message, as our calculation is an estimate.
-            _chatHistoryTokens[^1] = promptTokenCount - _totalInputToken;
-        }
-
-        _chatHistory.Add(response);
-        _chatHistoryTokens.Add(responseTokenCount);
-        _totalInputToken = promptTokenCount + responseTokenCount;
     }
 
     private void RefreshOpenAIClient()
@@ -110,7 +53,6 @@ internal class ChatService
         GPT old = _gptToUse;
         _gptToUse = _settings.Active;
         _chatHistory.Clear();
-        _chatHistoryTokens.Clear();
 
         if (old is not null
             && old.Type == _gptToUse.Type
@@ -124,6 +66,7 @@ internal class ChatService
             return;
         }
 
+        OpenAIChatClient client;
         EndpointType type = _gptToUse.Type;
         // Reasoning models do not support the temperature setting.
         _chatOptions.Temperature = _gptToUse.ModelInfo.Reasoning ? null : 0;
@@ -154,7 +97,7 @@ internal class ChatService
                     new ApiKeyCredential(azOpenAIApiKey),
                     clientOptions);
 
-                _client = aiClient.GetChatClient(_gptToUse.Deployment);
+                client = aiClient.GetChatClient(_gptToUse.Deployment);
             }
             else
             {
@@ -165,7 +108,7 @@ internal class ChatService
                     credential,
                     clientOptions);
 
-                _client = aiClient.GetChatClient(_gptToUse.Deployment);
+                client = aiClient.GetChatClient(_gptToUse.Deployment);
             }
         }
         else
@@ -179,26 +122,13 @@ internal class ChatService
 
             string userKey = Utils.ConvertFromSecureString(_gptToUse.Key);
             var aiClient = new OpenAIClient(new ApiKeyCredential(userKey), clientOptions);
-            _client = aiClient.GetChatClient(_gptToUse.ModelName);
-        }
-    }
-
-    /// <summary>
-    /// Reference: https://github.com/openai/openai-cookbook/blob/main/examples/How_to_count_tokens_with_tiktoken.ipynb
-    /// </summary>
-    private int CountTokenForUserMessage(UserChatMessage message)
-    {
-        ModelInfo modelDetail = _gptToUse.ModelInfo;
-        Tokenizer encoding = modelDetail.Encoding;
-
-        // Tokens per message plus 1 token for the role.
-        int tokenNumber = modelDetail.TokensPerMessage + 1;
-        foreach (ChatMessageContentPart part in message.Content)
-        {
-            tokenNumber += encoding.CountTokens(part.Text);
+            client = aiClient.GetChatClient(_gptToUse.ModelName);
         }
 
-        return tokenNumber;
+        _client = client.AsIChatClient()
+            .AsBuilder()
+            .UseFunctionInvocation()
+            .Build();
     }
 
     private void PrepareForChat(string input)
@@ -208,62 +138,25 @@ internal class ChatService
 
         if (_chatHistory.Count is 0)
         {
-            _chatHistory.Add(ChatMessage.CreateSystemMessage(_gptToUse.SystemPrompt));
-            _chatHistoryTokens.Add(0);
+            _chatHistory.Add(new(ChatRole.System, _gptToUse.SystemPrompt));
         }
 
-        var userMessage = new UserChatMessage(input);
-        int msgTokenCnt = CountTokenForUserMessage(userMessage);
-        _chatHistory.Add(userMessage);
-        _chatHistoryTokens.Add(msgTokenCnt);
-
-        int inputLimit = _gptToUse.ModelInfo.TokenLimit;
-        // Every reply is primed with <|start|>assistant<|message|>, so adding 3 tokens.
-        int newTotal = _totalInputToken + msgTokenCnt + 3;
-
-        // Shrink the chat history if we have less than 50 free tokens left (50-token buffer).
-        while (inputLimit - newTotal < 50)
-        {
-            // We remove a round of conversation for every trimming operation.
-            int userMsgCnt = 0;
-            List<int> indices = [];
-
-            for (int i = 0; i < _chatHistory.Count; i++)
-            {
-                if (_chatHistory[i] is UserChatMessage)
-                {
-                    if (userMsgCnt is 1)
-                    {
-                        break;
-                    }
-
-                    userMsgCnt++;
-                }
-
-                if (userMsgCnt is 1)
-                {
-                    indices.Add(i);
-                }
-            }
-
-            foreach (int i in indices)
-            {
-                newTotal -= _chatHistoryTokens[i];
-            }
-
-            _chatHistory.RemoveRange(indices[0], indices.Count);
-            _chatHistoryTokens.RemoveRange(indices[0], indices.Count);
-            _totalInputToken = newTotal - msgTokenCnt;
-        }
+        _chatHistory.Add(new(ChatRole.User, input));
     }
 
-    public async Task<IAsyncEnumerator<StreamingChatCompletionUpdate>> GetStreamingChatResponseAsync(string input, CancellationToken cancellationToken)
+    public async Task<IAsyncEnumerator<ChatResponseUpdate>> GetStreamingChatResponseAsync(string input, IShell shell, CancellationToken cancellationToken)
     {
         try
         {
             PrepareForChat(input);
-            IAsyncEnumerator<StreamingChatCompletionUpdate> enumerator = _client
-                .CompleteChatStreamingAsync(_chatHistory, _chatOptions, cancellationToken)
+            var tools = await shell.GetAIFunctions();
+            if (tools is { Count: > 0 })
+            {
+                _chatOptions.Tools = [.. tools];
+            }
+
+            IAsyncEnumerator<ChatResponseUpdate> enumerator = _client
+                .GetStreamingResponseAsync(_chatHistory, _chatOptions, cancellationToken)
                 .GetAsyncEnumerator(cancellationToken);
 
             return await enumerator


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

This PR enables MCP client support in AIShell and also updates the `openai-gpt` agent to consume tools.
The detailed changes are:
1. Updated the `AIShell.Abstraction.IShell` interface to include the following 2 new methods
    - `Task<List<AIFunction>> GetAIFunctions()` -- get available tools for AI model to use.
    - `Task<FunctionResultContent> CallAIFunction(...)` -- allow an agent to call a tool.

   We use types like `AIFunction`, `FunctionCallContent`, and `FunctionResultContent` from the NuGet package `Microsoft.Extensions.AI.Abstractions` as the general representation of a "_tool_", a "_tool call request_", and a "_tool call result_". This allows an agent to leverage the framework library `Microsoft.Extensions.AI` easily. And for agents that doesn't use that library, they can still use the exposed tools by calling `CallAIFunction(...)` directly.

2. Supported the `mcp.json` file for configuring local or remote MCP servers. Here is an example of the configuration format:
    ```JSONC
    {
      "servers": {
        "Everything": {
          "type": "stdio",
          "command": "npx",
          "args": ["-y", "@modelcontextprotocol/server-everything"]
        },
        "GitHub": {
          "type": "http",
          "url": "https://api.githubcopilot.com/mcp/",
          "headers": {
            "Authorization": "Bearer <github-pat>"
          }
        }
      }
    }
    ```
    **The configuration format is based on [that of the VS Code MCP](https://code.visualstudio.com/docs/copilot/chat/mcp-servers#_configuration-format), but not 100% the same -- no `envFile` key and no `inputs` support.**
    - Server configuration for `stdio` type connection:

      | Field     | Description                                                          | Examples          |
      |-----------|----------------------------------------------------------------------|-------------------|
      | `type`    | Server connection type.                                              | `"stdio"`         |
      | `command` | Command to start the server executable. The command needs to be available on your system path or full path. If you use docker, don't use the detach option. | `"npx"`, `"node"`, `"python"`, `"docker"`|
      | `args`    | Array of arguments passed to the command.                            | `["server.py", "--port", "3000"]`|
      | `env`     | Environment variables for the server.                                | `{"API_KEY": "<key>"}`|

    - Server configuration for `see` or `http` type connections:

      | Field     | Description                      | Examples          |
      |-----------|----------------------------------|-------------------|
      | `type`    | Server connection type. VS Code first tries the streamable HTTP transport and falls back to SSE if HTTP is not supported. | `"sse"`, `"http"` |
      | `url`     | URL of the server.               | `"http://localhost:3000"` |
      | `headers` | HTTP headers for the server.     | `{"API_KEY": "${input:api-key}"}` |

4. The new MCP components are:
    - `McpConfig`: it deserializes the `mcp.json` configuration utilizing source generation.
    - `McpManager`: it manages all configured MCP servers and expose methods to get all available tools, make a tool call, and stop/start a given server.
    - `McpServer`: it represents an MCP server. It connects to the server in asynchronous way, reports the server status, and return the available tools from the server.
    - `McpTool`: it represents an MCP tool. It implements `AIFunction` to hook up to the `Microsoft.Extensions.AI` framework and also make sure calls to MCP tools all go through the "tool call request" prompt for the user to approve.
    - `/mcp` command: it shows a table of all servers and their available tools, including the status of the server, and error message if a server fails.

    The MCP components depend on the official .NET MCP SDK `ModelContextProtocol.Core` to handle MCP servers under the hoods. Internally, our `McpServer` and `McpTool` wrap `IMcpClient` and `McpClientTool` respectively.

5. The `openai-gpt` agent was refactored to use the framework library `Microsoft.Extensions.AI.OpenAI`. This makes it extremely intuitive to consume exposed `AIFunction` instances from AIShell. The estimated token count tracking code was removed from the agent, because after switching to `Microsoft.Extensions.AI.OpenAI`, the framework library will make the subsequent round of chat requests automatically after a tool call result is back, and this will certainly not go through our existing token count tracking code. It was an estimate anyways, so if needed, we can use the token usage information from the response to help shrink the chat history.

6. Two new methods were added to `Host`
    - `RenderToolCallRequest` -- used by `McpTool` to display a tool call request.
    - `RenderMcpServersAndTools` -- used by `/mcp` command to display all servers and tools.

7. Updated `FancyStreamRender` to work properly when the host writes output while a `FancyStreamRender` is still active. It's very possible that an AI model could return some text before making a tool call. In such a case, the tool call request will be rendered while a `FancyStreamRender` instance is still active. A `FancyStreamRender` instance needs to track the initial cursor position to refresh the whole output when there are new text chunks coming in, so we need to make it aware of the tool call request output, so that it can adjust its cursor position and refresh its state correctly.

8. Updated `LoadContext.cs` to make sure for `System.CommandLine.dll` and `Microsoft.Extensions.AI.Abstractions.dll`, all agents share the same assembly loaded in the default load context. This is because the interfaces exposed in `AIShell.Abstraction` depend on types from those 2 assemblies, so if an agent loads its own version of those assemblies into its custom load context, the contracts will break.

9. Simplified the package references.

### Follow-up work

- Use the token usage information to shrink chat history
- `GetAIFunctions()` should only update the returned list when tools are changed.
- Built-in tools support -- run command and return results
- `/mcp` command should support the following sub commands:
   -  `/mcp stop <server>` -- stop a server.
   - `/mcp start <server>` -- start a server.
   - `/mcp refresh` -- refresh all servers if MCP configuration changed.