### PR TITLE
Add built-in tools to AIShell

### DIFF
--- a/shell/AIShell.Abstraction/NamedPipe.cs
+++ b/shell/AIShell.Abstraction/NamedPipe.cs
@@ -36,6 +36,32 @@ public enum MessageType : int
 }
 
 /// <summary>
+/// Context types that can be requested by AIShell from the connected PowerShell session.
+/// </summary>
+public enum ContextType : int
+{
+    /// <summary>
+    /// Ask for the current working directory of the shell.
+    /// </summary>
+    WorkingDirectory = 0,
+
+    /// <summary>
+    /// Ask for the command history of the shell session.
+    /// </summary>
+    CommandHistory = 1,
+
+    /// <summary>
+    /// Ask for the content of the terminal window.
+    /// </summary>
+    TerminalContent = 2,
+
+    /// <summary>
+    /// Ask for the environment variables of the shell session.
+    /// </summary>
+    EnvironmentVariables = 3,
+}
+
+/// <summary>
 /// Base class for all pipe messages.
 /// </summary>
 public abstract class PipeMessage
@@ -109,11 +135,23 @@ public sealed class AskConnectionMessage : PipeMessage
 public sealed class AskContextMessage : PipeMessage
 {
     /// <summary>
+    /// Gets the type of context information requested.
+    /// </summary>
+    public ContextType ContextType { get; }
+
+    /// <summary>
+    /// Gets the argument value associated with the current context query operation.
+    /// </summary>
+    public string[] Arguments { get; }
+
+    /// <summary>
     /// Creates an instance of <see cref="AskContextMessage"/>.
     /// </summary>
-    public AskContextMessage()
+    public AskContextMessage(ContextType contextType, string[] arguments = null)
         : base(MessageType.AskContext)
     {
+        ContextType = contextType;
+        Arguments = arguments ?? null;
     }
 }
 
@@ -125,21 +163,20 @@ public sealed class PostContextMessage : PipeMessage
     /// <summary>
     /// Represents a none instance to be used when the shell has no context information to return.
     /// </summary>
-    public static readonly PostContextMessage None = new([]);
+    public static readonly PostContextMessage None = new(contextInfo: null);
 
     /// <summary>
-    /// Gets the command history.
+    /// Gets the information of the requested context.
     /// </summary>
-    public List<string> CommandHistory { get; }
+    public string ContextInfo { get; }
 
     /// <summary>
     /// Creates an instance of <see cref="PostContextMessage"/>.
     /// </summary>
-    public PostContextMessage(List<string> commandHistory)
+    public PostContextMessage(string contextInfo)
         : base(MessageType.PostContext)
     {
-        ArgumentNullException.ThrowIfNull(commandHistory);
-        CommandHistory = commandHistory;
+        ContextInfo = contextInfo;
     }
 }
 

--- a/shell/AIShell.Abstraction/NamedPipe.cs
+++ b/shell/AIShell.Abstraction/NamedPipe.cs
@@ -43,7 +43,7 @@ public enum ContextType : int
     /// <summary>
     /// Ask for the current working directory of the shell.
     /// </summary>
-    WorkingDirectory = 0,
+    CurrentLocation = 0,
 
     /// <summary>
     /// Ask for the command history of the shell session.

--- a/shell/AIShell.Integration/AIShell.psm1
+++ b/shell/AIShell.Integration/AIShell.psm1
@@ -13,4 +13,4 @@ if ($null -eq $runspace) {
 }
 
 ## Create the channel singleton when loading the module.
-$null = [AIShell.Integration.Channel]::CreateSingleton($runspace, [Microsoft.PowerShell.PSConsoleReadLine])
+$null = [AIShell.Integration.Channel]::CreateSingleton($runspace, $ExecutionContext, [Microsoft.PowerShell.PSConsoleReadLine])

--- a/shell/AIShell.Integration/Channel.cs
+++ b/shell/AIShell.Integration/Channel.cs
@@ -368,7 +368,7 @@ public class Channel : IDisposable
         string contextInfo;
         switch (type)
         {
-            case ContextType.WorkingDirectory:
+            case ContextType.CurrentLocation:
                 contextInfo = JsonSerializer.Serialize(
                     new { Provider = _currentLocation.Provider.Name, _currentLocation.Path });
                 break;

--- a/shell/AIShell.Integration/Channel.cs
+++ b/shell/AIShell.Integration/Channel.cs
@@ -1,9 +1,13 @@
-﻿using System.Diagnostics;
+﻿using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.Reflection;
 using System.Text;
 using System.Management.Automation;
+using System.Management.Automation.Host;
 using System.Management.Automation.Runspaces;
 using AIShell.Abstraction;
+using Microsoft.PowerShell.Commands;
+using System.Text.Json;
 
 namespace AIShell.Integration;
 
@@ -15,13 +19,16 @@ public class Channel : IDisposable
     private readonly string _shellPipeName;
     private readonly Type _psrlType;
     private readonly Runspace _runspace;
+    private readonly EngineIntrinsics _intrinsics;
     private readonly MethodInfo _psrlInsert, _psrlRevertLine, _psrlAcceptLine;
     private readonly FieldInfo _psrlHandleResizing, _psrlReadLineReady;
     private readonly object _psrlSingleton;
     private readonly ManualResetEvent _connSetupWaitHandler;
     private readonly Predictor _predictor;
     private readonly ScriptBlock _onIdleAction;
+    private readonly List<HistoryInfo> _commandHistory;
 
+    private PathInfo _currentLocation;
     private ShellClientPipe _clientPipe;
     private ShellServerPipe _serverPipe;
     private bool? _setupSuccess;
@@ -29,14 +36,18 @@ public class Channel : IDisposable
     private Thread _serverThread;
     private CodePostData _pendingPostCodeData;
 
-    private Channel(Runspace runspace, Type psConsoleReadLineType)
+    private Channel(Runspace runspace, EngineIntrinsics intrinsics, Type psConsoleReadLineType)
     {
         ArgumentNullException.ThrowIfNull(runspace);
         ArgumentNullException.ThrowIfNull(psConsoleReadLineType);
 
         _runspace = runspace;
+        _intrinsics = intrinsics;
         _psrlType = psConsoleReadLineType;
         _connSetupWaitHandler = new ManualResetEvent(false);
+        _currentLocation = _intrinsics.SessionState.Path.CurrentLocation;
+        _runspace.AvailabilityChanged += RunspaceAvailableAction;
+        _intrinsics.InvokeCommand.LocationChangedAction += LocationChangedAction;
 
         _shellPipeName = new StringBuilder(MaxNamedPipeNameSize)
             .Append("pwsh_aish.")
@@ -57,13 +68,14 @@ public class Channel : IDisposable
         _psrlReadLineReady = _psrlType.GetField("_readLineReady", fieldFlags);
         _psrlHandleResizing = _psrlType.GetField("_handlePotentialResizing", fieldFlags);
 
+        _commandHistory = [];
         _predictor = new Predictor();
         _onIdleAction = ScriptBlock.Create("[AIShell.Integration.Channel]::Singleton.OnIdleHandler()");
     }
 
-    public static Channel CreateSingleton(Runspace runspace, Type psConsoleReadLineType)
+    public static Channel CreateSingleton(Runspace runspace, EngineIntrinsics intrinsics, Type psConsoleReadLineType)
     {
-        return Singleton ??= new Channel(runspace, psConsoleReadLineType);
+        return Singleton ??= new Channel(runspace, intrinsics, psConsoleReadLineType);
     }
 
     public static Channel Singleton { get; private set; }
@@ -127,6 +139,95 @@ public class Channel : IDisposable
         await _serverPipe.StartProcessingAsync(ConnectionTimeout, CancellationToken.None);
     }
 
+    private void LocationChangedAction(object sender, LocationChangedEventArgs e)
+    {
+        _currentLocation = e.NewPath;
+    }
+
+    private void RunspaceAvailableAction(object sender, RunspaceAvailabilityEventArgs e)
+    {
+        if (sender is null || e.RunspaceAvailability is not RunspaceAvailability.Available)
+        {
+            return;
+        }
+
+        // It's safe to get states of the PowerShell Runspace now because it's available and this event
+        // is handled synchronously.
+        // We may want to invoke command or script here, and we have to unregister ourself before doing
+        // that, because the invocation would change the availability of the Runspace, which will cause
+        // the 'AvailabilityChanged' to be fired again and re-enter our handler.
+        // We register ourself back after we are done with the processing.
+        var pwshRunspace = (Runspace)sender;
+        pwshRunspace.AvailabilityChanged -= RunspaceAvailableAction;
+
+        try
+        {
+            using var ps = PowerShell.Create();
+            ps.Runspace = pwshRunspace;
+
+            var results = ps
+                .AddCommand("Get-History")
+                .AddParameter("Count", 5)
+                .InvokeAndCleanup<HistoryInfo>();
+
+            if (results.Count is 0 ||
+                (_commandHistory.Count > 0 && _commandHistory[^1].Id == results[^1].Id))
+            {
+                // No command history yet, or no change since the last update.
+                return;
+            }
+
+            lock (_commandHistory)
+            {
+                _commandHistory.Clear();
+                _commandHistory.AddRange(results);
+            }
+        }
+        finally
+        {
+            pwshRunspace.AvailabilityChanged += RunspaceAvailableAction;
+        }
+    }
+
+    private string CaptureScreen()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return null;
+        }
+
+        try
+        {
+            PSHostRawUserInterface rawUI = _intrinsics.Host.UI.RawUI;
+            Coordinates start = new(0, 0), end = rawUI.CursorPosition;
+            end.X = rawUI.BufferSize.Width - 1;
+
+            BufferCell[,] content = rawUI.GetBufferContents(new Rectangle(start, end));
+            StringBuilder line = new(), buffer = new();
+
+            int rows = content.GetLength(0);
+            int columns = content.GetLength(1);
+
+            for (int row = 0; row < rows; row++)
+            {
+                line.Clear();
+                for (int column = 0; column < columns; column++)
+                {
+                    line.Append(content[row, column].Character);
+                }
+
+                line.TrimEnd();
+                buffer.Append(line).Append('\n');
+            }
+
+            return buffer.Length is 0 ? string.Empty : buffer.ToString();
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
     internal void PostQuery(PostQueryMessage message)
     {
         ThrowIfNotConnected();
@@ -138,6 +239,8 @@ public class Channel : IDisposable
         Reset();
         _connSetupWaitHandler.Dispose();
         _predictor.Unregister();
+        _runspace.AvailabilityChanged -= RunspaceAvailableAction;
+        _intrinsics.InvokeCommand.LocationChangedAction -= LocationChangedAction;
         GC.SuppressFinalize(this);
     }
 
@@ -257,8 +360,76 @@ public class Channel : IDisposable
 
     private PostContextMessage OnAskContext(AskContextMessage askContextMessage)
     {
-        // Not implemented yet.
-        return null;
+        const string RedactedValue = "***<sensitive data redacted>***";
+
+        ContextType type = askContextMessage.ContextType;
+        string[] arguments = askContextMessage.Arguments;
+
+        string contextInfo;
+        switch (type)
+        {
+            case ContextType.WorkingDirectory:
+                contextInfo = JsonSerializer.Serialize(
+                    new { Provider = _currentLocation.Provider.Name, _currentLocation.Path });
+                break;
+
+            case ContextType.CommandHistory:
+                lock (_commandHistory)
+                {
+                    contextInfo = JsonSerializer.Serialize(
+                        _commandHistory.Select(o => new { o.Id, o.CommandLine }));
+                }
+                break;
+
+            case ContextType.TerminalContent:
+                contextInfo = CaptureScreen();
+                break;
+
+            case ContextType.EnvironmentVariables:
+                if (arguments is { Length: > 0 })
+                {
+                    var varsCopy = new Dictionary<string, string>();
+                    foreach (string name in arguments)
+                    {
+                        if (!string.IsNullOrEmpty(name))
+                        {
+                            varsCopy.Add(name, Environment.GetEnvironmentVariable(name) is string value
+                                ? EnvVarMayBeSensitive(name) ? RedactedValue : value
+                                : $"[env variable '{arguments}' is undefined]");
+                        }
+                    }
+
+                    contextInfo = varsCopy.Count > 0
+                        ? JsonSerializer.Serialize(varsCopy)
+                        : "The specified environment variable names are invalid";
+                }
+                else
+                {
+                    var vars = Environment.GetEnvironmentVariables();
+                    var varsCopy = new Dictionary<string, string>();
+
+                    foreach (string key in vars.Keys)
+                    {
+                        varsCopy.Add(key, EnvVarMayBeSensitive(key) ? RedactedValue : (string)vars[key]);
+                    }
+
+                    contextInfo = JsonSerializer.Serialize(varsCopy);
+                }
+                break;
+
+            default:
+                throw new InvalidDataException($"Unknown context type '{type}'");
+        }
+
+        return new PostContextMessage(contextInfo);
+
+        static bool EnvVarMayBeSensitive(string key)
+        {
+            return key.Contains("key", StringComparison.OrdinalIgnoreCase) ||
+                key.Contains("token", StringComparison.OrdinalIgnoreCase) ||
+                key.Contains("pass", StringComparison.OrdinalIgnoreCase) ||
+                key.Contains("secret", StringComparison.OrdinalIgnoreCase);
+        }
     }
 
     private void OnAskConnection(ShellClientPipe clientPipe, Exception exception)
@@ -334,3 +505,39 @@ public class Channel : IDisposable
 }
 
 internal record CodePostData(string CodeToInsert, List<PredictionCandidate> PredictionCandidates);
+
+internal static class ExtensionMethods
+{
+    internal static Collection<T> InvokeAndCleanup<T>(this PowerShell ps)
+    {
+        var results = ps.Invoke<T>();
+        ps.Commands.Clear();
+
+        return results;
+    }
+
+    internal static void InvokeAndCleanup(this PowerShell ps)
+    {
+        ps.Invoke();
+        ps.Commands.Clear();
+    }
+
+    internal static void TrimEnd(this StringBuilder sb)
+    {
+        // end will point to the first non-trimmed character on the right.
+        int end = sb.Length - 1;
+        for (; end >= 0; end--)
+        {
+            if (!char.IsWhiteSpace(sb[end]))
+            {
+                break;
+            }
+        }
+
+        int index = end + 1;
+        if (index < sb.Length)
+        {
+            sb.Remove(index, sb.Length - index);
+        }
+    }
+}

--- a/shell/AIShell.Integration/Commands/InvokeAishCommand.cs
+++ b/shell/AIShell.Integration/Commands/InvokeAishCommand.cs
@@ -17,8 +17,8 @@ public class InvokeAIShellCommand : PSCmdlet
     /// <summary>
     /// Sets and gets the query to be sent to AIShell
     /// </summary>
-    [Parameter(Mandatory = true, ValueFromRemainingArguments = true, ParameterSetName = DefaultSet)]
-    [Parameter(Mandatory = true, ValueFromRemainingArguments = true, ParameterSetName = ClipboardSet)]
+    [Parameter(Position = 0, ParameterSetName = DefaultSet)]
+    [Parameter(Position = 0, ParameterSetName = ClipboardSet)]
     public string[] Query { get; set; }
 
     /// <summary>
@@ -88,6 +88,26 @@ public class InvokeAIShellCommand : PSCmdlet
                 message = "/exit";
                 break;
             default:
+                if (Query is not null)
+                {
+                    message = string.Join(' ', Query);
+                }
+                else
+                {
+                    Host.UI.Write("Query: ");
+                    message = Host.UI.ReadLine();
+                }
+
+                if (string.IsNullOrEmpty(message))
+                {
+                    ThrowTerminatingError(
+                        new ErrorRecord(
+                            new ArgumentException("A query message is required."),
+                            "QueryIsMissing",
+                            ErrorCategory.InvalidArgument,
+                            targetObject: null));
+                }
+
                 Collection<string> results = null;
                 if (_contextObjects is not null)
                 {
@@ -107,7 +127,6 @@ public class InvokeAIShellCommand : PSCmdlet
                 }
 
                 context = results?.Count > 0 ? results[0] : null;
-                message = string.Join(' ', Query);
                 break;
         }
 

--- a/shell/AIShell.Kernel/Command/CodeCommand.cs
+++ b/shell/AIShell.Kernel/Command/CodeCommand.cs
@@ -36,12 +36,6 @@ internal sealed class CodeCommand : CommandBase
         copy.SetHandler(CopyAction, nth);
         save.SetHandler(SaveAction, file, append);
         post.SetHandler(PostAction, nth);
-
-        var get = new Command("get", "Post context information.");
-        var ctx = new Argument<string>("context");
-        get.AddArgument(ctx);
-        get.SetHandler(GetAction, ctx);
-        AddCommand(get);
     }
 
     private static string GetCodeText(Shell shell, int index)
@@ -181,31 +175,6 @@ internal sealed class CodeCommand : CommandBase
             shell.Channel.PostCode(new PostCodeMessage(codeToPost));
             host.WriteLine("Code posted to the connected application.");
             shell.OnUserAction(new CodePayload(UserAction.CodePost, string.Join("\n\n", codeToPost)));
-        }
-        catch (Exception e)
-        {
-            host.WriteErrorLine(e.Message);
-        }
-    }
-
-    private async Task GetAction(string context)
-    {
-        var shell = (Shell)Shell;
-        var host = shell.Host;
-
-        if (shell.Channel is null)
-        {
-            host.WriteErrorLine("Cannot get context information because the bi-directional channel was not established.");
-            return;
-        }
-
-        try
-        {
-            var type = Enum.Parse<ContextType>(context);
-            var message = new AskContextMessage(type);
-
-            PostContextMessage response = await shell.Channel.AskContext(message, shell.CancellationToken);
-            host.WriteLine(response.ContextInfo);
         }
         catch (Exception e)
         {

--- a/shell/AIShell.Kernel/Command/McpCommand.cs
+++ b/shell/AIShell.Kernel/Command/McpCommand.cs
@@ -28,8 +28,9 @@ internal sealed class McpCommand : CommandBase
     {
         var shell = (Shell)Shell;
         var host = shell.Host;
+        var mcpManager = shell.McpManager;
 
-        if (shell.McpManager.McpServers.Count is 0)
+        if (mcpManager.McpServers.Count is 0 && mcpManager.BuiltInTools is null)
         {
             host.WriteErrorLine("No MCP server is available.");
             return;

--- a/shell/AIShell.Kernel/Host.cs
+++ b/shell/AIShell.Kernel/Host.cs
@@ -662,6 +662,20 @@ internal sealed class Host : IHost
             }
         }
 
+        if (mcpManager.BuiltInTools is { Count: > 0 })
+        {
+            if (toolTable.Rows is { Count: > 0 })
+            {
+                toolTable.AddEmptyRow();
+            }
+
+            toolTable.AddRow($"[olive underline]{McpManager.BuiltInServerName}[/]", "[green]\u2713 Ready[/]", string.Empty);
+            foreach (var item in mcpManager.BuiltInTools)
+            {
+                toolTable.AddRow(string.Empty, item.Key.EscapeMarkup(), item.Value.Description.EscapeMarkup());
+            }
+        }
+
         if (readyServers is not null)
         {
             foreach (var (name, status, info) in readyServers)

--- a/shell/AIShell.Kernel/MCP/BuiltInTool.cs
+++ b/shell/AIShell.Kernel/MCP/BuiltInTool.cs
@@ -1,10 +1,7 @@
 ﻿using AIShell.Abstraction;
 using Microsoft.Extensions.AI;
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices.ObjectiveC;
 using System.Text.Json;
-using System.Xml.Linq;
 
 namespace AIShell.Kernel.Mcp;
 
@@ -12,7 +9,7 @@ internal class BuiltInTool : AIFunction
 {
     private enum ToolType : int
     {
-        get_current_location = 0,
+        get_working_directory = 0,
         get_command_history = 1,
         get_terminal_content = 2,
         get_environment_variables = 3,
@@ -25,8 +22,8 @@ internal class BuiltInTool : AIFunction
 
     private static readonly string[] s_toolDescription =
     [
-        // get_current_location
-        "Get the current location of the connected PowerShell session, including the provider name (e.g., `FileSystem`, `Certificate`) and the path (e.g., `C:\\`, `cert:\\`).",
+        // get_working_directory
+        "Get the current working directory of the connected PowerShell session, including the provider name (e.g., `FileSystem`, `Certificate`) and the path (e.g., `C:\\`, `cert:\\`).",
 
         // get_command_history
         "Get up to 5 of the most recent commands executed in the connected PowerShell session.",
@@ -74,7 +71,7 @@ internal class BuiltInTool : AIFunction
 
     private static readonly string[] s_toolSchema =
     [
-        // get_current_location
+        // get_working_directory
         """
         {
           "type": "object",
@@ -272,7 +269,7 @@ internal class BuiltInTool : AIFunction
     {
         AskContextMessage contextRequest = _toolType switch
         {
-            ToolType.get_current_location => new(ContextType.CurrentLocation),
+            ToolType.get_working_directory => new(ContextType.CurrentLocation),
             ToolType.get_command_history => new(ContextType.CommandHistory),
             ToolType.get_terminal_content => new(ContextType.TerminalContent),
             ToolType.get_environment_variables => new(

--- a/shell/AIShell.Kernel/MCP/BuiltInTool.cs
+++ b/shell/AIShell.Kernel/MCP/BuiltInTool.cs
@@ -1,0 +1,427 @@
+﻿using AIShell.Abstraction;
+using Microsoft.Extensions.AI;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices.ObjectiveC;
+using System.Text.Json;
+using System.Xml.Linq;
+
+namespace AIShell.Kernel.Mcp;
+
+internal class BuiltInTool : AIFunction
+{
+    private enum ToolType : int
+    {
+        get_current_location = 0,
+        get_command_history = 1,
+        get_terminal_content = 2,
+        get_environment_variables = 3,
+        copy_text_to_clipboard = 4,
+        post_code_to_terminal = 5,
+        run_command_in_terminal = 6,
+        get_terminal_output = 7,
+        NumberOfBuiltInTools = 8
+    };
+
+    private static readonly string[] s_toolDescription =
+    [
+        // get_current_location
+        "Get the current location of the connected PowerShell session, including the provider name (e.g., `FileSystem`, `Certificate`) and the path (e.g., `C:\\`, `cert:\\`).",
+
+        // get_command_history
+        "Get up to 5 of the most recent commands executed in the connected PowerShell session.",
+
+        // get_terminal_content
+        "Get all output currently displayed in the terminal window of the connected PowerShell session.",
+
+        //get_environment_variables
+        "Get environment variables and their values from the connected PowerShell session. Values of potentially sensitive variables are redacted.",
+
+        // copy_text_to_clipboard
+        "Copy the provided text or code to the system clipboard, making it available for pasting elsewhere.",
+
+        // post_code_to_terminal
+        "Insert code into the prompt of the connected PowerShell session without executing it. The user can review and choose to run it manually by pressing Enter.",
+
+        // run_command_in_terminal
+        """
+        This tool allows you to execute shell commands in a persistent PowerShell session, preserving environment variables, working directory, and other context across multiple commands.
+
+        Command Execution:
+        - Supports chaining with `&&` or `;` (e.g., npm install && npm start).
+        - Supports multi-line commands
+
+        Directory Management:
+        - Use absolute paths to avoid navigation issues.
+
+        Program Execution:
+        - Supports running PowerShell commands and scripts.
+        - Supports Python, Node.js, and other executables.
+        - Install dependencies via pip, npm, etc.
+
+        Background Processes:
+        - For long-running tasks (e.g., servers), set `isBackground=true`.
+        - Returns a terminal ID for checking status and runtime later.
+
+        Important Notes:
+        - If the command may produce excessively large output, use head or tail to reduce the output.
+        - If a command may use a pager, you must add something to disable it. For example, you can use `git --no-pager`. Otherwise you should add something like ` | cat`. Examples: git, less, man, etc.
+        """,
+
+        // get_terminal_output
+        "Get the output of a command previous started with `run_command_in_terminal`"
+    ];
+
+    private static readonly string[] s_toolSchema =
+    [
+        // get_current_location
+        """
+        {
+          "type": "object",
+          "properties": {},
+          "additionalProperties": false,
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        }
+        """,
+
+        // get_command_history
+        """
+        {
+          "type": "object",
+          "properties": {},
+          "additionalProperties": false,
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        }
+        """,
+
+        // get_terminal_content
+        """
+        {
+          "type": "object",
+          "properties": {},
+          "additionalProperties": false,
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        }
+        """,
+
+        // get_environment_variables
+        """
+        {
+          "type": "object",
+          "properties": {
+            "names": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null,
+              "description": "Environment variable names to get values for. When no name is specified, returns all environment variables."
+            }
+          },
+          "additionalProperties": false,
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        }
+        """,
+
+        // copy_text_to_clipboard
+        """
+        {
+          "type": "object",
+          "properties": {
+            "content": {
+              "type": "string",
+              "description": "Text or code to be copied to the system clipboard."
+            }
+          },
+          "required": [
+            "content"
+          ],
+          "additionalProperties": false,
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        }
+        """,
+
+        // post_code_to_terminal
+        """
+        {
+          "type": "object",
+          "properties": {
+            "command": {
+              "type": "string",
+              "description": "Command or code snippet to be inserted to the terminal's prompt."
+            }
+          },
+          "required": [
+            "command"
+          ],
+          "additionalProperties": false,
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        }
+        """,
+
+        // run_command_in_terminal
+        """
+        {
+          "type": "object",
+          "properties": {
+            "command": {
+              "type": "string",
+              "description": "Command to run in the connected PowerShell session."
+            },
+            "explanation": {
+              "type": "string",
+              "description": "A one-sentence description of what the command does. This will be shown to the user before the command is run."
+            },
+            "isBackground": {
+              "type": "boolean",
+              "description": "Whether the command starts a background process. If true, the command will run in the background and you will not see the output. If false, the tool call will block on the command finishing, and then you will get the output. Examples of backgrond processes: building in watch mode, starting a server. You can check the output of a backgrond process later on by using get_terminal_output."
+            }
+          },
+          "required": [
+            "command",
+            "explanation",
+            "isBackground"
+          ],
+          "additionalProperties": false,
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        }
+        """,
+
+        // get_terminal_output
+        """
+        {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The ID of the command to get the output from. This is the ID returned by the `run_command_in_terminal` tool."
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "additionalProperties": false,
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        }
+        """
+    ];
+
+    private readonly string _fullName;
+    private readonly string _toolName;
+    private readonly ToolType _toolType;
+    private readonly string _description;
+    private readonly JsonElement _jsonSchema;
+    private readonly Shell _shell;
+
+    private BuiltInTool(ToolType toolType, string description, JsonElement schema, Shell shell)
+    {
+        _toolType = toolType;
+        _shell = shell;
+        _toolName = toolType.ToString();
+        _description = description;
+        _jsonSchema = schema;
+
+        _fullName = $"{McpManager.BuiltInServerName}{McpManager.ServerToolSeparator}{_toolName}";
+    }
+
+    /// <summary>
+    /// The original tool name without the server name prefix.
+    /// </summary>
+    internal string OriginalName => _toolName;
+
+    /// <summary>
+    /// The fully qualified name of the tool in the form of '<server-name>.<tool-name>'
+    /// </summary>
+    public override string Name => _fullName;
+
+    /// <inheritdoc />
+    public override string Description => _description;
+
+    /// <inheritdoc />
+    public override JsonElement JsonSchema => _jsonSchema;
+
+    /// <summary>
+    /// Overrides the base method with the call to <see cref="CallAsync"/>.
+    /// </summary>
+    protected override async ValueTask<object> InvokeCoreAsync(AIFunctionArguments arguments, CancellationToken cancellationToken)
+    {
+        var response = await CallAsync(arguments, cancellationToken).ConfigureAwait(false);
+        if (response is PostContextMessage postContextMsg)
+        {
+            return postContextMsg.ContextInfo;
+        }
+
+        return response is null ? "Success: Function completed." : JsonSerializer.SerializeToElement(response);
+    }
+
+    /// <summary>
+    /// Invokes the built-in tool.
+    /// </summary>
+    /// <param name="arguments">
+    /// An optional dictionary of arguments to pass to the tool.
+    /// Each key represents a parameter name, and its associated value represents the argument value.
+    /// </param>
+    /// <param name="cancellationToken">
+    /// The cancellation token to monitor for cancellation requests.
+    /// The default is <see cref="CancellationToken.None" />.
+    /// </param>
+    /// <exception cref="OperationCanceledException">The user rejected the tool call.</exception>
+    internal async Task<PipeMessage> CallAsync(
+        IReadOnlyDictionary<string, object> arguments = null,
+        CancellationToken cancellationToken = default)
+    {
+        AskContextMessage contextRequest = _toolType switch
+        {
+            ToolType.get_current_location => new(ContextType.CurrentLocation),
+            ToolType.get_command_history => new(ContextType.CommandHistory),
+            ToolType.get_terminal_content => new(ContextType.TerminalContent),
+            ToolType.get_environment_variables => new(
+                ContextType.EnvironmentVariables,
+                TryGetArgumentValue(arguments, "names", out string[] names)
+                    ? names is { Length: > 0 } ? names : null
+                    : null),
+            _ => null
+        };
+
+        bool succeeded = false;
+        PostContextMessage response = null;
+
+        if (contextRequest is not null)
+        {
+            succeeded = true;
+            response = await _shell.Host.RunWithSpinnerAsync(
+                async () => await _shell.Channel.AskContext(contextRequest, cancellationToken),
+                status: $"Running '{_toolName}'",
+                spinnerKind: SpinnerKind.Processing);
+        }
+        else if (_toolType is ToolType.copy_text_to_clipboard)
+        {
+            TryGetArgumentValue(arguments, "content", out string content);
+
+            if (string.IsNullOrEmpty(content))
+            {
+                throw new ArgumentException("The 'content' argument is required for the 'copy_text_to_clipboard' tool.");
+            }
+
+            succeeded = true;
+            Clipboard.SetText(content);
+        }
+        else if (_toolType is ToolType.post_code_to_terminal)
+        {
+            TryGetArgumentValue(arguments, "command", out string command);
+
+            if (string.IsNullOrEmpty(command))
+            {
+                throw new ArgumentException("The 'command' argument is required for the 'post_code_to_terminal' tool.");
+            }
+
+            succeeded = true;
+            _shell.Channel.PostCode(new PostCodeMessage([command]));
+        }
+
+        if (succeeded)
+        {
+            // Notify the user about this tool call.
+            _shell.Host.MarkupLine($"\n    [green]\u2713[/] Ran '{_toolName}'");
+            // Signal any active stream reander about the output
+            FancyStreamRender.ConsoleUpdated();
+
+            return response;
+        }
+
+        throw new NotSupportedException($"Tool type '{_toolType}' is not yet supported.");
+    }
+
+    private static bool TryGetArgumentValue<T>(IReadOnlyDictionary<string, object> arguments, string argName, out T value)
+    {
+        if (arguments is null || !arguments.TryGetValue(argName, out object argValue))
+        {
+            value = default;
+            return false;
+        }
+
+        if (argValue is T tValue)
+        {
+            value = tValue;
+            return true;
+        }
+
+        if (argValue is JsonElement json)
+        {
+            Type tType = typeof(T);
+            JsonValueKind kind = json.ValueKind;
+
+            if (tType == typeof(string))
+            {
+                if (kind is JsonValueKind.String)
+                {
+                    object stringValue = json.GetString();
+                    value = (T)stringValue;
+                    return true;
+                }
+
+                value = default;
+                return kind is JsonValueKind.Null;
+            }
+
+            if (tType == typeof(string[]))
+            {
+                if (kind is JsonValueKind.Array)
+                {
+                    object stringArray = json.EnumerateArray().Select(e => e.GetString()).ToArray();
+                    value = (T)stringArray;
+                    return true;
+                }
+
+                value = default;
+                return kind is JsonValueKind.Null;
+            }
+
+            if (tType == typeof(bool) && kind is JsonValueKind.True or JsonValueKind.False)
+            {
+                value = (T)(object)json.GetBoolean();
+                return true;
+            }
+
+            if (tType == typeof(int) && kind is JsonValueKind.Number)
+            {
+                value = (T)(object)json.GetInt32();
+                return true;
+            }
+        }
+
+        value = default;
+        return false;
+    }
+
+    /// <summary>
+    /// Gets the list of built-in tools available in AIShell.
+    /// </summary>
+    internal static Dictionary<string, BuiltInTool> GetBuiltInTools(Shell shell)
+    {
+        ArgumentNullException.ThrowIfNull(shell);
+
+        // We don't have the 'run_command' and 'get_terminal_output' tools yet. Will use 'ToolType.NumberOfBuiltInTools' when all tools are ready.
+        int toolCount = (int)ToolType.run_command_in_terminal;
+        Debug.Assert(s_toolDescription.Length == (int)ToolType.NumberOfBuiltInTools, "Number of tool descriptions doesn't match the number of tools.");
+        Debug.Assert(s_toolSchema.Length == (int)ToolType.NumberOfBuiltInTools, "Number of tool schemas doesn't match the number of tools.");
+
+        if (shell.Channel is null || !shell.Channel.Connected)
+        {
+            return null;
+        }
+
+        Dictionary<string, BuiltInTool> tools = new(StringComparer.OrdinalIgnoreCase);
+        for (int i = 0; i < toolCount; i++)
+        {
+            ToolType toolType = (ToolType)i;
+            string description = s_toolDescription[i];
+            JsonElement schema = JsonSerializer.Deserialize<JsonElement>(s_toolSchema[i]);
+            BuiltInTool tool = new(toolType, description, schema, shell);
+
+            tools.Add(tool.OriginalName, tool);
+        }
+
+        return tools;
+    }
+}

--- a/shell/AIShell.Kernel/MCP/McpConfig.cs
+++ b/shell/AIShell.Kernel/MCP/McpConfig.cs
@@ -188,6 +188,7 @@ internal enum McpType
     PropertyNameCaseInsensitive = true,
     ReadCommentHandling = JsonCommentHandling.Skip,
     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    NumberHandling = JsonNumberHandling.AllowReadingFromString,
     UseStringEnumConverter = true)]
 [JsonSerializable(typeof(McpConfig))]
 [JsonSerializable(typeof(McpServerConfig))]

--- a/shell/AIShell.Kernel/MCP/McpTool.cs
+++ b/shell/AIShell.Kernel/MCP/McpTool.cs
@@ -12,21 +12,23 @@ namespace AIShell.Kernel.Mcp;
 /// </summary>
 internal class McpTool : AIFunction
 {
+    internal static readonly string[] UserChoices = ["Continue", "Cancel"];
+
     private readonly string _fullName;
     private readonly string _serverName;
     private readonly Host _host;
     private readonly McpClientTool _clientTool;
-    private readonly string[] _userChoices;
-
-    internal const string ServerToolSeparator = "___";
 
     internal McpTool(string serverName, McpClientTool clientTool, Host host)
     {
+        ArgumentException.ThrowIfNullOrEmpty(serverName);
+        ArgumentNullException.ThrowIfNull(clientTool);
+        ArgumentNullException.ThrowIfNull(host);
+
         _host = host;
         _clientTool = clientTool;
-        _fullName = $"{serverName}{ServerToolSeparator}{clientTool.Name}";
+        _fullName = $"{serverName}{McpManager.ServerToolSeparator}{clientTool.Name}";
         _serverName = serverName;
-        _userChoices = ["Continue", "Cancel"];
     }
 
     /// <summary>
@@ -117,7 +119,7 @@ internal class McpTool : AIFunction
         const string title = "\n\u26A0  MCP servers or malicious converstaion content may attempt to misuse 'AIShell' through the installed tools. Please carefully review any requested actions to decide if you want to proceed.";
         string choice = await _host.PromptForSelectionAsync(
             title: title,
-            choices: _userChoices,
+            choices: UserChoices,
             cancellationToken: cancellationToken);
 
         if (choice is "Cancel")


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

This PR exposes built-in tools to agents of AIShell. The built-in tools are also exposed as `AIFunction` instances so they can be consumed similarly as the MCP client tools.
The detailed changes are:

1. Updated the channel between the `AIShell` module and `aish` app to support retrieving context information from the connected PowerShell session. The supported context information includes:
    - `CurrentLocation` 
    - `CommandHistory` 
    - `TerminalContent`
    - `EnvironmentVariables`

2. Updated the `AIShell` module to
    - keep track of the "current location" and "command history" using `Runspace.AvailabilityChanged` and `InvokeCommand.LocationChangedAction` events.
    - support retrieving terminal window content on Windows using screen scraping.
    - support get environment variables and their values (value for a sensitive env var is redacted)

3. Added the `BuiltInTool` type that inherits `AIFunction`. This type has the implementation for both the discovery and invocation of the built-in tool. Built-in tools all depend on a connected PowerShell session being available, so today, for the standalone `aish`, no built-in tools are available. The following built-in tools are supported with this PR:
   - `get_working_directory`
   - `get_command_history`
   - `get_terminal_content`
   - `get_environment_variables`
   - `copy_text_to_clipboard`
   - `post_code_to_terminal`
 
   `run_command_in_terminal` and `get_terminal_output` will come in a separate PR.

5. Updated `McpManager` to expose built-in tools to agents, and call built-in tools as needed.

6. Updated `Host` to show built-in tools along with available MCP servers/tools.