### PR TITLE
Fix a null-reference exception bug when built-in tools are not available

### DIFF
--- a/shell/AIShell.Kernel/MCP/McpManager.cs
+++ b/shell/AIShell.Kernel/MCP/McpManager.cs
@@ -81,7 +81,7 @@ internal class McpManager
         await _initTask;
 
         List<AIFunction> tools = null;
-        if (_builtInTools.Count > 0)
+        if (_builtInTools is { Count: > 0 })
         {
             (tools ??= []).AddRange(_builtInTools.Values);
         }


### PR DESCRIPTION

### PR Summary

Fix a null-reference exception bug when built-in tools are not available.
