### PR TITLE
Add the built-in tool `run_command_in_terminal` for AI to execute commands in the connected PowerShell session

### DIFF
--- a/shell/AIShell.Integration/AIShell.psd1
+++ b/shell/AIShell.Integration/AIShell.psd1
@@ -10,9 +10,9 @@
     PowerShellVersion = '7.4.6'
     PowerShellHostName = 'ConsoleHost'
     FunctionsToExport = @()
-    CmdletsToExport = @('Start-AIShell','Invoke-AIShell','Resolve-Error')
+    CmdletsToExport = @('Start-AIShell','Invoke-AIShell', 'Invoke-AICommand', 'Resolve-Error')
     VariablesToExport = '*'
-    AliasesToExport = @('aish', 'askai', 'fixit')
+    AliasesToExport = @('aish', 'askai', 'fixit', 'airun')
     HelpInfoURI = 'https://aka.ms/aishell-help'
     PrivateData = @{ PSData = @{ Prerelease = 'preview5'; ProjectUri = 'https://github.com/PowerShell/AIShell' } }
 }

--- a/shell/AIShell.Integration/Channel.cs
+++ b/shell/AIShell.Integration/Channel.cs
@@ -25,7 +25,8 @@ public class Channel : IDisposable
     private readonly object _psrlSingleton;
     private readonly ManualResetEvent _connSetupWaitHandler;
     private readonly Predictor _predictor;
-    private readonly ScriptBlock _onIdleAction;
+    private readonly ScriptBlock _onIdlePostAction;
+    private readonly ScriptBlock _onIdleRunAction;
     private readonly List<HistoryInfo> _commandHistory;
 
     private PathInfo _currentLocation;
@@ -35,6 +36,8 @@ public class Channel : IDisposable
     private Exception _exception;
     private Thread _serverThread;
     private CodePostData _pendingPostCodeData;
+    private RunCommandRequest _runCommandRequest;
+    private PowerShell _pwsh;
 
     private Channel(Runspace runspace, EngineIntrinsics intrinsics, Type psConsoleReadLineType)
     {
@@ -70,7 +73,8 @@ public class Channel : IDisposable
 
         _commandHistory = [];
         _predictor = new Predictor();
-        _onIdleAction = ScriptBlock.Create("[AIShell.Integration.Channel]::Singleton.OnIdleHandler()");
+        _onIdlePostAction = ScriptBlock.Create("[AIShell.Integration.Channel]::Singleton.OnIdlePostHandler()");
+        _onIdleRunAction = ScriptBlock.Create("[AIShell.Integration.Channel]::Singleton.OnIdleRunHandler()");
     }
 
     public static Channel CreateSingleton(Runspace runspace, EngineIntrinsics intrinsics, Type psConsoleReadLineType)
@@ -106,6 +110,29 @@ public class Channel : IDisposable
         return false;
     }
 
+    /// <summary>
+    /// A 'run_command' tool call request will set '_runCommandRequest' properly with the 'Result' property being null.
+    /// For a blocking call, it will set '_runCommandRequest' back to null once the call result has been set.
+    /// For an unblocking call, '_runCommandRequest' will remain as is until:
+    ///   1. a 'get_output' request comes to collect the result, or
+    ///   2. another 'run_command' request comes to run a new command.
+    /// So we consider there is a pending request only if '_runCommandRequest' is not null and its 'Result' property is null.
+    /// </summary>
+    internal string GetRunCommandRequest() =>
+        _runCommandRequest is { Result: null } ? _runCommandRequest.Command : null;
+
+    /// <summary>
+    /// Set the command result for a 'run_command' tool call request.
+    /// </summary>
+    internal void SetRunCommandResult(bool hadErrors, bool userCancelled, List<object> errorAndOutput)
+    {
+        if (_runCommandRequest is { Result: null })
+        {
+            _runCommandRequest.Result = new(hadErrors, userCancelled, errorAndOutput);
+            _runCommandRequest.Event?.Set();
+        }
+    }
+
     public string StartChannelSetup()
     {
         if (_serverPipe is not null)
@@ -123,12 +150,13 @@ public class Channel : IDisposable
         _serverPipe.OnAskConnection += OnAskConnection;
         _serverPipe.OnAskContext += OnAskContext;
         _serverPipe.OnPostCode += OnPostCode;
+        _serverPipe.OnRunCommand += OnRunCommand;
 
         _serverThread = new Thread(ThreadProc)
-            {
-                IsBackground = true,
-                Name = "pwsh channel thread"
-            };
+        {
+            IsBackground = true,
+            Name = "pwsh channel thread"
+        };
 
         _serverThread.Start();
         return _shellPipeName;
@@ -255,6 +283,7 @@ public class Channel : IDisposable
             _serverPipe.OnAskConnection -= OnAskConnection;
             _serverPipe.OnAskContext -= OnAskContext;
             _serverPipe.OnPostCode -= OnPostCode;
+            _serverPipe.OnRunCommand -= OnRunCommand;
         }
 
         _serverPipe = null;
@@ -284,12 +313,23 @@ public class Channel : IDisposable
     }
 
     [Hidden()]
-    public void OnIdleHandler()
+    public void OnIdlePostHandler()
     {
         if (_pendingPostCodeData is not null)
         {
             PSRLInsert(_pendingPostCodeData.CodeToInsert);
             _predictor.SetCandidates(_pendingPostCodeData.PredictionCandidates);
+            _pendingPostCodeData = null;
+        }
+    }
+
+    [Hidden()]
+    public void OnIdleRunHandler()
+    {
+        if (_pendingPostCodeData is not null)
+        {
+            PSRLInsert(_pendingPostCodeData.CodeToInsert);
+            PSRLAcceptLine();
             _pendingPostCodeData = null;
         }
     }
@@ -351,7 +391,7 @@ public class Channel : IDisposable
                 eventName: null,
                 sourceIdentifier: PSEngineEvent.OnIdle,
                 data: null,
-                action: _onIdleAction,
+                action: _onIdlePostAction,
                 supportEvent: true,
                 forwardEvent: false,
                 maxTriggerCount: 1);
@@ -446,6 +486,86 @@ public class Channel : IDisposable
         }
 
         _connSetupWaitHandler.Set();
+    }
+
+    private PostContextMessage OnAskContext(AskContextMessage askContextMessage)
+    {
+        // Not implemented yet.
+        return null;
+    }
+
+    private PostResultMessage OnRunCommand(RunCommandMessage runCommandMessage)
+    {
+        // Ignore 'run_command' request when a code posting operation is on-going.
+        if (_pendingPostCodeData is not null)
+        {
+            return new PostResultMessage(
+                output: "Cannot run command at the moment. Try again later.",
+                hadError: true,
+                userCancelled: false,
+                exception: null);
+        }
+
+        string command = runCommandMessage.Command.Replace("\r\n", "\n");
+        _runCommandRequest = new(command, runCommandMessage.Blocking);
+
+        string codeToInsert = command.Contains('\n')
+            ? $$"""
+                airun {
+                {{command}}
+                }
+                """
+            : $"airun {{ {command} }}";
+
+        // When PSReadLine is actively running, its '_readLineReady' field should be set to 'true'.
+        // When the value is 'false', it means PowerShell is still busy running scripts or commands.
+        if (_psrlReadLineReady.GetValue(_psrlSingleton) is true)
+        {
+            PSRLRevertLine();
+        }
+
+        _pendingPostCodeData = new CodePostData(codeToInsert, null);
+        // We use script block handler instead of a delegate handler because the latter will run
+        // in a background thread, while the former will run in the pipeline thread, which is way
+        // more predictable.
+        _runspace.Events.SubscribeEvent(
+            source: null,
+            eventName: null,
+            sourceIdentifier: PSEngineEvent.OnIdle,
+            data: null,
+            action: _onIdleRunAction,
+            supportEvent: true,
+            forwardEvent: false,
+            maxTriggerCount: 1);
+
+        if (runCommandMessage.Blocking)
+        {
+            // Wait for the call to finish.
+            _runCommandRequest.Event.Wait();
+            RunCommandResult result = _runCommandRequest.Result;
+
+            _pwsh ??= PowerShell.Create();
+            _pwsh.Commands.Clear();
+            string output = result.ErrorAndOutput.Count is 0
+                ? string.Empty
+                : _pwsh.AddCommand("Out-String")
+                    .AddParameter("InputObject", result.ErrorAndOutput)
+                    .AddParameter("Width", 120)
+                    .Invoke<string>()[0];
+
+            PostResultMessage response = new(
+                output: output,
+                hadError: result.HadErrors,
+                userCancelled: result.UserCancelled,
+                exception: null);
+
+            _runCommandRequest.Dispose();
+            _runCommandRequest = null;
+
+            return response;
+        }
+
+        return new PostResultMessage(output: _runCommandRequest.Id, hadError: false, userCancelled: false, exception: null);
     }
 
     private void PSRLInsert(string text)

--- a/shell/AIShell.Integration/Channel.cs
+++ b/shell/AIShell.Integration/Channel.cs
@@ -212,6 +212,10 @@ public class Channel : IDisposable
                 _commandHistory.AddRange(results);
             }
         }
+        catch
+        {
+            // Ignore unexpected exceptions.
+        }
         finally
         {
             pwshRunspace.AvailabilityChanged += RunspaceAvailableAction;

--- a/shell/AIShell.Integration/Commands/InvokeAiCommand.cs
+++ b/shell/AIShell.Integration/Commands/InvokeAiCommand.cs
@@ -1,0 +1,90 @@
+namespace AIShell.Integration.Commands;
+
+using System.Management.Automation;
+
+[Alias("airun")]
+[Cmdlet(VerbsLifecycle.Invoke, "AICommand")]
+public sealed class InvokeAICommand : PSCmdlet, IDisposable
+{
+    private readonly PowerShell _pwsh;
+    private readonly PSDataCollection<PSObject> _output;
+
+    private bool _disposed, _hadErrors, _cancelled;
+    private List<object> _capturedContent;
+
+    [Parameter(Mandatory = true, Position = 0)]
+    public ScriptBlock Command { get; set; }
+
+    public InvokeAICommand()
+    {
+        _pwsh = PowerShell.Create(RunspaceMode.CurrentRunspace);
+        _pwsh.Streams.Error.DataAdding += DataAddingHandler;
+
+        _output = [];
+        _output.DataAdding += DataAddingHandler;
+        _capturedContent = null;
+    }
+
+    /// <summary>
+    /// The handler for both 'OutputDataAdding' and 'ErrorDataAdding' events.
+    /// </summary>
+    /// <remarks>
+    /// The handler is called on the pipeline thread, so it's safe to call 'WriteObject' in it.
+    /// </remarks>
+    private void DataAddingHandler(object sender, DataAddingEventArgs e)
+    {
+        object item = e.ItemAdded;
+        _capturedContent?.Add(item);
+        WriteObject(item);
+    }
+
+    protected override void EndProcessing()
+    {
+        string commandToRun = Command.ToString();
+        string requestedCommand = Channel.Singleton.GetRunCommandRequest();
+
+        if (requestedCommand is not null && commandToRun.Contains(requestedCommand))
+        {
+            // Only capture output when this is a tool call invoked by AI.
+            _capturedContent = [];
+        }
+
+        try
+        {
+            _pwsh.AddScript(commandToRun, useLocalScope: false);
+            _pwsh.Invoke(input: null, _output, settings: null);
+        }
+        finally
+        {
+            _hadErrors = _pwsh.HadErrors;
+        }
+    }
+
+    protected override void StopProcessing()
+    {
+        _pwsh.Stop();
+        _cancelled = true;
+    }
+
+    /// <summary>
+    /// Dispose the resources.
+    /// </summary>
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        if (_capturedContent is { })
+        {
+            Channel.Singleton.SetRunCommandResult(_hadErrors, _cancelled, _capturedContent);
+        }
+
+        _output.DataAdding -= DataAddingHandler;
+        _output.Dispose();
+        _pwsh.Streams.Error.DataAdding -= DataAddingHandler;
+        _pwsh.Dispose();
+        _disposed = true;
+    }
+}

--- a/shell/AIShell.Integration/RunInTerminal.cs
+++ b/shell/AIShell.Integration/RunInTerminal.cs
@@ -1,0 +1,40 @@
+namespace AIShell.Integration;
+
+internal class RunCommandRequest : IDisposable
+{
+    internal string Id { get; }
+    internal string Command { get; }
+    internal ManualResetEventSlim Event { get; }
+    internal RunCommandResult Result { get; set; }
+
+    internal RunCommandRequest(string command, bool blockingCall)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(command);
+
+        Id = Guid.NewGuid().ToString();
+        Command = command;
+        Event = blockingCall ? new() : null;
+        Result = null;
+    }
+
+    public void Dispose()
+    {
+        Event?.Dispose();
+    }
+}
+
+internal class RunCommandResult
+{
+    internal bool HadErrors { get; }
+    internal bool UserCancelled { get; }
+    internal List<object> ErrorAndOutput { get; }
+
+    internal RunCommandResult(bool hadErrors, bool userCancelled, List<object> errorAndOutput)
+    {
+        ArgumentNullException.ThrowIfNull(errorAndOutput);
+
+        HadErrors = hadErrors;
+        UserCancelled = userCancelled;
+        ErrorAndOutput = errorAndOutput;
+    }
+}

--- a/shell/AIShell.Kernel/Command/CodeCommand.cs
+++ b/shell/AIShell.Kernel/Command/CodeCommand.cs
@@ -36,13 +36,6 @@ internal sealed class CodeCommand : CommandBase
         copy.SetHandler(CopyAction, nth);
         save.SetHandler(SaveAction, file, append);
         post.SetHandler(PostAction, nth);
-
-
-        var run = new Command("run", "Run the specified command.");
-        var command = new Argument<string>("command", "command to run");
-        run.AddArgument(command);
-        run.SetHandler(RunAction, command);
-        AddCommand(run);
     }
 
     private static string GetCodeText(Shell shell, int index)
@@ -187,14 +180,5 @@ internal sealed class CodeCommand : CommandBase
         {
             host.WriteErrorLine(e.Message);
         }
-    }
-
-    private async Task RunAction(string command)
-    {
-        var shell = (Shell)Shell;
-        var host = shell.Host;
-        var result = await shell.Channel.RunCommand(new RunCommandMessage(command, blocking: true), shell.CancellationToken);
-
-        host.WriteLine($"HadError: {result.HadError}\nUserCancelled: {result.UserCancelled}\nOutput: {result.Output}\nException: {result.Exception}");
     }
 }

--- a/shell/AIShell.Kernel/Command/CodeCommand.cs
+++ b/shell/AIShell.Kernel/Command/CodeCommand.cs
@@ -36,6 +36,13 @@ internal sealed class CodeCommand : CommandBase
         copy.SetHandler(CopyAction, nth);
         save.SetHandler(SaveAction, file, append);
         post.SetHandler(PostAction, nth);
+
+
+        var run = new Command("run", "Run the specified command.");
+        var command = new Argument<string>("command", "command to run");
+        run.AddArgument(command);
+        run.SetHandler(RunAction, command);
+        AddCommand(run);
     }
 
     private static string GetCodeText(Shell shell, int index)
@@ -180,5 +187,14 @@ internal sealed class CodeCommand : CommandBase
         {
             host.WriteErrorLine(e.Message);
         }
+    }
+
+    private async Task RunAction(string command)
+    {
+        var shell = (Shell)Shell;
+        var host = shell.Host;
+        var result = await shell.Channel.RunCommand(new RunCommandMessage(command, blocking: true), shell.CancellationToken);
+
+        host.WriteLine($"HadError: {result.HadError}\nUserCancelled: {result.UserCancelled}\nOutput: {result.Output}\nException: {result.Exception}");
     }
 }

--- a/shell/AIShell.Kernel/Host.cs
+++ b/shell/AIShell.Kernel/Host.cs
@@ -570,9 +570,9 @@ internal sealed class Host : IHost
     /// </summary>
     /// <param name="tool">The MCP tool.</param>
     /// <param name="jsonArgs">The arguments in JSON form to be sent for the tool call.</param>
-    internal void RenderToolCallRequest(McpTool tool, string jsonArgs)
+    internal void RenderMcpToolCallRequest(McpTool tool, string jsonArgs)
     {
-        RequireStdoutOrStderr(operation: "render tool call request");
+        RequireStdoutOrStderr(operation: "render MCP tool call request");
         IAnsiConsole ansiConsole = _outputRedirected ? _stderrConsole : AnsiConsole.Console;
 
         bool hasArgs = !string.IsNullOrEmpty(jsonArgs);
@@ -597,6 +597,44 @@ internal sealed class Host : IHost
                 .AddColumn(new GridColumn())
                 .AddRow(content)
                 .AddRow(json);
+        }
+
+        var panel = new Panel(content)
+            .Expand()
+            .RoundedBorder()
+            .Header("[green]  Tool Call Request  [/]")
+            .BorderColor(Color.Grey);
+
+        ansiConsole.WriteLine();
+        ansiConsole.Write(panel);
+        FancyStreamRender.ConsoleUpdated();
+    }
+
+    /// <summary>
+    /// Render the built-in tool call request.
+    /// </summary>
+    internal void RenderBuiltInToolCallRequest(string toolName, string description, Tuple<string, string> argument)
+    {
+        RequireStdoutOrStderr(operation: "render built-in tool call request");
+        IAnsiConsole ansiConsole = _outputRedirected ? _stderrConsole : AnsiConsole.Console;
+
+        bool hasArgs = argument is not null;
+        string argLine = hasArgs ? $"{argument.Item1}:" : $"Input: <none>";
+        IRenderable content = new Markup($"""
+
+            [bold]Run [olive]{toolName}[/] from [olive]{McpManager.BuiltInServerName}[/] (Built-in tool)[/]
+
+            {description}
+
+            {argLine}
+            """);
+
+        if (hasArgs)
+        {
+            content = new Grid()
+                .AddColumn(new GridColumn())
+                .AddRow(content)
+                .AddRow(argument.Item2.EscapeMarkup());
         }
 
         var panel = new Panel(content)
@@ -672,7 +710,13 @@ internal sealed class Host : IHost
             toolTable.AddRow($"[olive underline]{McpManager.BuiltInServerName}[/]", "[green]\u2713 Ready[/]", string.Empty);
             foreach (var item in mcpManager.BuiltInTools)
             {
-                toolTable.AddRow(string.Empty, item.Key.EscapeMarkup(), item.Value.Description.EscapeMarkup());
+                string description = item.Value.Description;
+                int index = description.IndexOf('\n');
+                if (index > 0)
+                {
+                    description = description[..index].Trim();
+                }
+                toolTable.AddRow(string.Empty, item.Key.EscapeMarkup(), description.EscapeMarkup());
             }
         }
 

--- a/shell/AIShell.Kernel/MCP/BuiltInTool.cs
+++ b/shell/AIShell.Kernel/MCP/BuiltInTool.cs
@@ -1,6 +1,7 @@
 ﻿using AIShell.Abstraction;
 using Microsoft.Extensions.AI;
 using System.Diagnostics;
+using System.Text;
 using System.Text.Json;
 
 namespace AIShell.Kernel.Mcp;
@@ -16,7 +17,7 @@ internal class BuiltInTool : AIFunction
         copy_text_to_clipboard = 4,
         post_code_to_terminal = 5,
         run_command_in_terminal = 6,
-        get_terminal_output = 7,
+        get_command_output = 7,
         NumberOfBuiltInTools = 8
     };
 
@@ -58,15 +59,15 @@ internal class BuiltInTool : AIFunction
 
         Background Processes:
         - For long-running tasks (e.g., servers), set `isBackground=true`.
-        - Returns a terminal ID for checking status and runtime later.
+        - Returns a command ID for checking status and output later.
 
         Important Notes:
         - If the command may produce excessively large output, use head or tail to reduce the output.
         - If a command may use a pager, you must add something to disable it. For example, you can use `git --no-pager`. Otherwise you should add something like ` | cat`. Examples: git, less, man, etc.
         """,
 
-        // get_terminal_output
-        "Get the output of a command previous started with `run_command_in_terminal`"
+        // get_command_output
+        "Get the output of a command previously started with `run_command_in_terminal`."
     ];
 
     private static readonly string[] s_toolSchema =
@@ -171,7 +172,7 @@ internal class BuiltInTool : AIFunction
             },
             "isBackground": {
               "type": "boolean",
-              "description": "Whether the command starts a background process. If true, the command will run in the background and you will not see the output. If false, the tool call will block on the command finishing, and then you will get the output. Examples of backgrond processes: building in watch mode, starting a server. You can check the output of a backgrond process later on by using get_terminal_output."
+              "description": "Whether the command starts a background process. If true, the command will run in the background and you will not see the output. If false, the tool call will block on the command finishing, and then you will get the output. Examples of backgrond processes: building in watch mode, starting a server. You can check the output of a backgrond process later on by using `get_command_output`."
             }
           },
           "required": [
@@ -184,7 +185,7 @@ internal class BuiltInTool : AIFunction
         }
         """,
 
-        // get_terminal_output
+        // get_command_output
         """
         {
           "type": "object",
@@ -248,6 +249,22 @@ internal class BuiltInTool : AIFunction
             return postContextMsg.ContextInfo;
         }
 
+        if (response is PostResultMessage postResultMsg)
+        {
+            StringBuilder strb = new(postResultMsg.Output.Length + 40);
+            strb.AppendLine("### Status")
+                .AppendLine(postResultMsg.UserCancelled
+                    ? "Execution was cancelled by the user."
+                    : postResultMsg.HadError ? "Had error." : "Succeeded.")
+                .AppendLine()
+                .AppendLine("### Output")
+                .AppendLine("```")
+                .AppendLine(postResultMsg.Output.Trim())
+                .AppendLine("```");
+
+            return strb.ToString();
+        }
+
         return response is null ? "Success: Function completed." : JsonSerializer.SerializeToElement(response);
     }
 
@@ -267,6 +284,7 @@ internal class BuiltInTool : AIFunction
         IReadOnlyDictionary<string, object> arguments = null,
         CancellationToken cancellationToken = default)
     {
+        PipeMessage response = null;
         AskContextMessage contextRequest = _toolType switch
         {
             ToolType.get_working_directory => new(ContextType.CurrentLocation),
@@ -280,12 +298,8 @@ internal class BuiltInTool : AIFunction
             _ => null
         };
 
-        bool succeeded = false;
-        PostContextMessage response = null;
-
         if (contextRequest is not null)
         {
-            succeeded = true;
             response = await _shell.Host.RunWithSpinnerAsync(
                 async () => await _shell.Channel.AskContext(contextRequest, cancellationToken),
                 status: $"Running '{_toolName}'",
@@ -294,39 +308,74 @@ internal class BuiltInTool : AIFunction
         else if (_toolType is ToolType.copy_text_to_clipboard)
         {
             TryGetArgumentValue(arguments, "content", out string content);
-
             if (string.IsNullOrEmpty(content))
             {
                 throw new ArgumentException("The 'content' argument is required for the 'copy_text_to_clipboard' tool.");
             }
 
-            succeeded = true;
             Clipboard.SetText(content);
         }
         else if (_toolType is ToolType.post_code_to_terminal)
         {
             TryGetArgumentValue(arguments, "command", out string command);
-
             if (string.IsNullOrEmpty(command))
             {
                 throw new ArgumentException("The 'command' argument is required for the 'post_code_to_terminal' tool.");
             }
 
-            succeeded = true;
             _shell.Channel.PostCode(new PostCodeMessage([command]));
         }
-
-        if (succeeded)
+        else if (_toolType is ToolType.run_command_in_terminal)
         {
-            // Notify the user about this tool call.
-            _shell.Host.MarkupLine($"\n    [green]\u2713[/] Ran '{_toolName}'");
-            // Signal any active stream reander about the output
-            FancyStreamRender.ConsoleUpdated();
+            TryGetArgumentValue(arguments, "command", out string command);
+            TryGetArgumentValue(arguments, "explanation", out string explanation);
+            TryGetArgumentValue(arguments, "isBackground", out bool isBackground);
 
-            return response;
+            if (string.IsNullOrEmpty(command))
+            {
+                throw new ArgumentException("The 'command' argument is required for the 'run_command_in_terminal' tool.");
+            }
+            if (string.IsNullOrEmpty(explanation))
+            {
+                throw new ArgumentException("The 'explanation' argument is required for the 'run_command_in_terminal' tool.");
+            }
+
+            _shell.Host.RenderBuiltInToolCallRequest(OriginalName, explanation, Tuple.Create("command", command));
+            // Prompt for user's approval to call the tool.
+            const string title = "\n\u26A0  Malicious converstaion content may attempt to misuse 'AIShell' through the built-in tools. Please carefully review any requested actions to decide if you want to proceed.";
+            string choice = await _shell.Host.PromptForSelectionAsync(
+                title: title,
+                choices: McpTool.UserChoices,
+                cancellationToken: cancellationToken);
+
+            if (choice is "Cancel")
+            {
+                _shell.Host.MarkupLine($"\n    [red]\u2717[/] Cancelled '{OriginalName}'");
+                throw new OperationCanceledException("The call was rejected by user.");
+            }
+
+            response = await _shell.Host.RunWithSpinnerAsync(
+                async () => await _shell.Channel.RunCommand(new RunCommandMessage(command, blocking: !isBackground), cancellationToken),
+                status: $"Running '{_toolName}'",
+                spinnerKind: SpinnerKind.Processing);
+        }
+        else if (_toolType is ToolType.get_command_output)
+        {
+            TryGetArgumentValue(arguments, "id", out string id);
+            if (string.IsNullOrEmpty(id))
+            {
+                throw new ArgumentException("The 'id' argument is required for the 'get_command_output' tool.");
+            }
+
+            response = await _shell.Channel.AskCommandOutput(new AskCommandOutputMessage(id), cancellationToken);
         }
 
-        throw new NotSupportedException($"Tool type '{_toolType}' is not yet supported.");
+        // Notify the user about this tool call.
+        _shell.Host.MarkupLine($"\n    [green]\u2713[/] Ran '{_toolName}'");
+
+        // Signal any active stream render about the output.
+        FancyStreamRender.ConsoleUpdated();
+        return response;
     }
 
     private static bool TryGetArgumentValue<T>(IReadOnlyDictionary<string, object> arguments, string argName, out T value)
@@ -398,8 +447,8 @@ internal class BuiltInTool : AIFunction
     {
         ArgumentNullException.ThrowIfNull(shell);
 
-        // We don't have the 'run_command' and 'get_terminal_output' tools yet. Will use 'ToolType.NumberOfBuiltInTools' when all tools are ready.
-        int toolCount = (int)ToolType.run_command_in_terminal;
+        // We don't have the 'run_command' and 'get_command_output' tools yet. Will use 'ToolType.NumberOfBuiltInTools' when all tools are ready.
+        int toolCount = (int)ToolType.NumberOfBuiltInTools;
         Debug.Assert(s_toolDescription.Length == (int)ToolType.NumberOfBuiltInTools, "Number of tool descriptions doesn't match the number of tools.");
         Debug.Assert(s_toolSchema.Length == (int)ToolType.NumberOfBuiltInTools, "Number of tool schemas doesn't match the number of tools.");
 

--- a/shell/AIShell.Kernel/MCP/BuiltInTool.cs
+++ b/shell/AIShell.Kernel/MCP/BuiltInTool.cs
@@ -447,7 +447,6 @@ internal class BuiltInTool : AIFunction
     {
         ArgumentNullException.ThrowIfNull(shell);
 
-        // We don't have the 'run_command' and 'get_command_output' tools yet. Will use 'ToolType.NumberOfBuiltInTools' when all tools are ready.
         int toolCount = (int)ToolType.NumberOfBuiltInTools;
         Debug.Assert(s_toolDescription.Length == (int)ToolType.NumberOfBuiltInTools, "Number of tool descriptions doesn't match the number of tools.");
         Debug.Assert(s_toolSchema.Length == (int)ToolType.NumberOfBuiltInTools, "Number of tool schemas doesn't match the number of tools.");

--- a/shell/AIShell.Kernel/MCP/BuiltInTool.cs
+++ b/shell/AIShell.Kernel/MCP/BuiltInTool.cs
@@ -342,7 +342,7 @@ internal class BuiltInTool : AIFunction
 
             _shell.Host.RenderBuiltInToolCallRequest(OriginalName, explanation, Tuple.Create("command", command));
             // Prompt for user's approval to call the tool.
-            const string title = "\n\u26A0  Malicious converstaion content may attempt to misuse 'AIShell' through the built-in tools. Please carefully review any requested actions to decide if you want to proceed.";
+            const string title = "\n\u26A0  Malicious conversation content may attempt to misuse 'AIShell' through the built-in tools. Please carefully review any requested actions to decide if you want to proceed.";
             string choice = await _shell.Host.PromptForSelectionAsync(
                 title: title,
                 choices: McpTool.UserChoices,

--- a/shell/AIShell.Kernel/MCP/McpTool.cs
+++ b/shell/AIShell.Kernel/MCP/McpTool.cs
@@ -116,7 +116,7 @@ internal class McpTool : AIFunction
         _host.RenderMcpToolCallRequest(this, jsonArgs);
 
         // Prompt for user's approval to call the tool.
-        const string title = "\n\u26A0  MCP servers or malicious converstaion content may attempt to misuse 'AIShell' through the installed tools. Please carefully review any requested actions to decide if you want to proceed.";
+        const string title = "\n\u26A0  MCP servers or malicious conversation content may attempt to misuse 'AIShell' through the installed tools. Please carefully review any requested actions to decide if you want to proceed.";
         string choice = await _host.PromptForSelectionAsync(
             title: title,
             choices: UserChoices,

--- a/shell/AIShell.Kernel/MCP/McpTool.cs
+++ b/shell/AIShell.Kernel/MCP/McpTool.cs
@@ -113,7 +113,7 @@ internal class McpTool : AIFunction
         string jsonArgs = arguments is { Count: > 0 }
             ? JsonSerializer.Serialize(arguments, serializerOptions ?? JsonSerializerOptions)
             : null;
-        _host.RenderToolCallRequest(this, jsonArgs);
+        _host.RenderMcpToolCallRequest(this, jsonArgs);
 
         // Prompt for user's approval to call the tool.
         const string title = "\n\u26A0  MCP servers or malicious converstaion content may attempt to misuse 'AIShell' through the installed tools. Please carefully review any requested actions to decide if you want to proceed.";

--- a/shell/AIShell.Kernel/ShellIntegration/Channel.cs
+++ b/shell/AIShell.Kernel/ShellIntegration/Channel.cs
@@ -212,6 +212,15 @@ internal class Channel : IDisposable
         return await _clientPipe.AskContext(message, cancellationToken);
     }
 
+    /// <summary>
+    /// Run command in the connected shell.
+    /// </summary>
+    internal async Task<PostResultMessage> RunCommand(RunCommandMessage message, CancellationToken cancellationToken)
+    {
+        ThrowIfNotConnected();
+        return await _clientPipe.RunCommand(message, cancellationToken);
+    }
+
     public void Dispose()
     {
         if (_disposed)

--- a/shell/AIShell.Kernel/ShellIntegration/Channel.cs
+++ b/shell/AIShell.Kernel/ShellIntegration/Channel.cs
@@ -221,6 +221,15 @@ internal class Channel : IDisposable
         return await _clientPipe.RunCommand(message, cancellationToken);
     }
 
+    /// <summary>
+    /// Ask for the output of a command that was previously run in the connected shell.
+    /// </summary>
+    internal async Task<PostResultMessage> AskCommandOutput(AskCommandOutputMessage message, CancellationToken cancellationToken)
+    {
+        ThrowIfNotConnected();
+        return await _clientPipe.AskCommandOutput(message, cancellationToken);
+    }
+
     public void Dispose()
     {
         if (_disposed)

--- a/shell/agents/AIShell.OpenAI.Agent/Helpers.cs
+++ b/shell/agents/AIShell.OpenAI.Agent/Helpers.cs
@@ -195,7 +195,7 @@ internal static class Prompt
     internal static string SystemPromptWithConnectedPSSession = $"""
         You are a virtual assistant in **AIShell**, specializing in PowerShell and other command-line tools.
 
-        You are connected to an interactive PowerShell session and can retrieve session context and interact with the session using built-in tools. When user queries are ambiguous or minimal, rely on session context to better understand intent and deliver accurate, helpful responses..
+        You are connected to an interactive PowerShell session and can retrieve session context and run commands in the session using built-in tools. When user queries are ambiguous or minimal, rely on session context to better understand intent and deliver accurate, helpful responses.
 
         Your primary function is to assist users with accomplishing tasks and troubleshooting errors in the command line. Autonomously resolve the user's query to the best of your ability before returning with a response.
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Allow AIShell to run command in the connected PowerShell session and collect all output and error.

1. Add `Invoke-AICommand` cmdlet (alias: `airun`) to `AIShell` module. Commands sent from the sidecar AIShell will be executed through this command in the form of `airun { <command> }`. This command is designed to collect all output and error messages as they are displayed in the terminal, while preserving the streaming behavior as expected.

2. Add `RunCommand` and `PostResult` messages to the protocol.

3. Update the `Channel` class in `AIShell` module to support the `OnRunCommand` action. We already support posting command to the PowerShell's prompt, but it turns out not easy to make the command be accepted. On Windows, we have to call `AcceptLine` within an `OnIdle` event handler and it also requires changes to `PSReadLine`.
    - `AcceptLine` only set a flag in `PSReadLine` to indicate the line was accepted. The flag is checked in `InputLoop`, however, when `PSReadLine` is waiting for input, it's blocked in the `ReadKey` call within `InputLoop`, so even if the flag is set, `InputLoop` won't be able to check the flag until after `ReadKey` call is returned.
    - I need to change PSReadLine a bit: after it finishes handling the `OnIdle` event, it checks if the `_lineAccepted` flag is set. If it's set, it means `AcceptLine` got called within the `OnIdle` handler, and it throws a `LineAcceptedException` to break out from `ReadKey`. I catch this exception in `InputLoop` to continue with the flag check.
    - However, a problem with this change is: the "readkey thread" is still blocked on `Console.ReadKey` when the command is returned to PowerShell to execute. On Windows, this could cause minor issues if the command also calls `Console.ReadKey` -- 2 threads calling `Console.ReadKey` in parallel, so it's uncertain which will get the next keystroke input. On macOS and Linux, the problem is way much bigger -- any subsequent writing to the terminal may be blocked, because on Unix platforms, reading cursor position will be blocked if another thread is calling `Console.ReadKey`.
    - So, this approach can only work on Windows. On macOS, we will have to depend on `iTerm2`, which has a Python API server that allows to send keystrokes to a tab using the Python API, so we could possibly use that for macOS. But Windows Terminal doesn't support that, and thus we will have to use the above approach to accept the command on Windows.
    - On macOS, if the Python API approach works fine, then we could even consider using it for the `PostCode` action.

4. Add `run_command_in_terminal` and `get_command_output` tools and expose them to agents.
