### PR TITLE
Merge the 1.0.0-preview.6 release branch back to main

### DIFF
--- a/shell/AIShell.Integration/AIShell.psd1
+++ b/shell/AIShell.Integration/AIShell.psd1
@@ -1,7 +1,7 @@
 @{
     RootModule = 'AIShell.psm1'
     NestedModules = @("AIShell.Integration.dll")
-    ModuleVersion = '1.0.5'
+    ModuleVersion = '1.0.6'
     GUID = 'ECB8BEE0-59B9-4DAE-9D7B-A990B480279A'
     Author = 'Microsoft Corporation'
     CompanyName = 'Microsoft Corporation'
@@ -14,5 +14,5 @@
     VariablesToExport = '*'
     AliasesToExport = @('aish', 'askai', 'fixit', 'airun')
     HelpInfoURI = 'https://aka.ms/aishell-help'
-    PrivateData = @{ PSData = @{ Prerelease = 'preview5'; ProjectUri = 'https://github.com/PowerShell/AIShell' } }
+    PrivateData = @{ PSData = @{ Prerelease = 'preview6'; ProjectUri = 'https://github.com/PowerShell/AIShell' } }
 }

--- a/shell/AIShell.Integration/AIShell.psm1
+++ b/shell/AIShell.Integration/AIShell.psm1
@@ -3,8 +3,8 @@ if ($IsMacOS -and $env:TERM_PROGRAM -ne "iTerm.app") {
 }
 
 $module = Get-Module -Name PSReadLine
-if ($null -eq $module -or $module.Version -lt [version]"2.4.2") {
-    throw "The PSReadLine v2.4.2-beta2 or higher is required for the AIShell module to work properly."
+if ($null -eq $module -or $module.Version -lt [version]"2.4.3") {
+    throw "The PSReadLine v2.4.3-beta3 or higher is required for the AIShell module to work properly."
 }
 
 $runspace = $Host.Runspace

--- a/shell/AIShell.Kernel/MCP/BuiltInTool.cs
+++ b/shell/AIShell.Kernel/MCP/BuiltInTool.cs
@@ -447,9 +447,14 @@ internal class BuiltInTool : AIFunction
     {
         ArgumentNullException.ThrowIfNull(shell);
 
-        int toolCount = (int)ToolType.NumberOfBuiltInTools;
         Debug.Assert(s_toolDescription.Length == (int)ToolType.NumberOfBuiltInTools, "Number of tool descriptions doesn't match the number of tools.");
         Debug.Assert(s_toolSchema.Length == (int)ToolType.NumberOfBuiltInTools, "Number of tool schemas doesn't match the number of tools.");
+
+        // TODO: 'run_command_in_terminal' and 'get_command_output' don't work on macOS yet.
+        // On macOS, we need to use the iTerm2's python API to send the 'Enter' key to accept the command.
+        int toolCount = OperatingSystem.IsWindows()
+            ? (int)ToolType.NumberOfBuiltInTools
+            : (int)ToolType.run_command_in_terminal;
 
         if (shell.Channel is null || !shell.Channel.Connected)
         {

--- a/shell/shell.common.props
+++ b/shell/shell.common.props
@@ -8,7 +8,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>12.0</LangVersion>
-    <Version>1.0.0-preview.5</Version>
+    <Version>1.0.0-preview.6</Version>
 
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/tools/metadata.json
+++ b/tools/metadata.json
@@ -1,3 +1,3 @@
 {
-    "AgentsToInclude": "*"
+    "AgentsToInclude": ["msaz", "openai-gpt"]
 }

--- a/tools/metadata.json
+++ b/tools/metadata.json
@@ -1,3 +1,3 @@
 {
-    "AgentsToInclude": ["msaz", "openai-gpt"]
+    "AgentsToInclude": "*"
 }

--- a/tools/scripts/install-aishell.ps1
+++ b/tools/scripts/install-aishell.ps1
@@ -20,7 +20,10 @@ $Script:InstallLocation = $null
 $Script:PackageURL = $null
 $Script:ModuleVersion = $null
 $Script:NewPSRLInstalled = $false
-$Script:PSRLDependencyMap = @{ '1.0.4-preview4' = '2.4.2-beta2' }
+$Script:PSRLDependencyMap = @{
+    '1.0.4-preview4' = '2.4.2-beta2'
+    '1.0.6-preview6' = '2.4.3-beta3'
+}
 
 function Resolve-Environment {
     if ($PSVersionTable.PSVersion -lt [version]"7.4.6") {
@@ -211,7 +214,8 @@ function Install-AIShellModule {
     Write-Host "Installing the PowerShell module 'AIShell' $modVersion ..."
     Install-PSResource -Name AIShell -Repository PSGallery -Prerelease -TrustRepository -Version $modVersion -ErrorAction Stop -WarningAction SilentlyContinue
 
-    $psrldep = $Script:PSRLDependencyMap[$modVersion]
+    $psrldep = GetPSRLDependency -modVersion $modVersion
+
     if ($psrldep) {
         $psrlModule = Get-Module -Name PSReadLine
         $psrlVer = $psrldep.Contains('-') ? $psrldep.Split('-')[0] : $psrldep
@@ -226,6 +230,23 @@ function Install-AIShellModule {
     if ($IsMacOS) {
         Write-Host -ForegroundColor Yellow "NOTE: The 'AIShell' PowerShell module only works in iTerm2 terminal in order to provide the sidecar experience."
     }
+}
+
+function GetPSRLDependency {
+    param([string] $modVersion)
+
+    $keys = $Script:PSRLDependencyMap.Keys
+    $curVer = [version]($modVersion.Contains('-') ? $modVersion.Split('-')[0] : $modVersion)
+
+    $psrldep = $null
+    foreach ($key in $keys) {
+        $ver = $key.Contains('-') ? $key.Split('-')[0] : $key
+        if ($curVer -ge [version]$ver) {
+            $psrldep = $Script:PSRLDependencyMap[$key]
+        }
+    }
+
+    return $psrldep
 }
 
 function Uninstall-AIShellModule {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

- Increment the versions for AIShell application and the AIShell module.
- Update the check in AIShell module to look for PSReadLine v2.4.3-beta3 and above.
- Hide the `run_command_in_terminal` tool in macOS.
- Update the installation script to find the right PSReadLine dependency for a particular version of AIShell module.
