### PR TITLE
Use login shell to start `aish` in sidecar pane to inherit proper environment PATH

### DIFF
--- a/shell/AIShell.Integration/InitAndCleanup.cs
+++ b/shell/AIShell.Integration/InitAndCleanup.cs
@@ -7,7 +7,7 @@ namespace AIShell.Integration;
 
 public class InitAndCleanup : IModuleAssemblyInitializer, IModuleAssemblyCleanup
 {
-    private const int ScriptVersion = 1;
+    private const int ScriptVersion = 2;
     private const string ScriptFileTemplate = "aish_split_pane_v{0}.py";
     private const string SplitPanePythonCode = """
         import iterm2
@@ -31,7 +31,8 @@ public class InitAndCleanup : IModuleAssemblyInitializer, IModuleAssemblyCleanup
 
                 change = iterm2.LocalWriteOnlyProfile()
                 change.set_use_custom_command('Yes')
-                change.set_command(f'{app_path} --channel {channel}')
+                # Use login shell to inherit proper PATH and environment
+                change.set_command(f'/bin/zsh -l -c "{app_path} --channel {channel}"')
 
                 # Split pane vertically
                 split_pane = await current_pane.async_split_pane(vertical=True, profile_customizations=change)


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

On macOS, when using the sidecar experience, `aish` cannot start local MCP servers and the `Azure` agent cannot get the access token from Az CLI.

This is due to the PATH environment variable not properly setup when iTerm2 starts `"aish --Channel ..."` in the new pane. iTerm2 uses `exec` to run the `aish` command, which directly execute the program without setting up the environment variables properly.

Because of that, the `az` and `pwsh` commands cannot be found when retrieving access token, and the MCP server commands cannot be found too, which caused local MCP servers to always fail to start.

The fix is to wrap it with `zsh` by `/bin/zsh -l -c "<aish-path> --channel <channel-string>"`. In this way, `zsh` will set up the environment properly, which will then be inherited by `aish`.

-----

This also fixes https://github.com/PowerShell/AIShell/issues/380. After using the shell wrapper, I can no longer reproduce this issue. It's possibly because the shell wrapper makes it slower to get to the selection rendering code, which magically avoid the race condition.
