### PR TITLE
Properly escape tool description to avoid malformed 'Markup' object

### DIFF
--- a/shell/AIShell.Kernel/Host.cs
+++ b/shell/AIShell.Kernel/Host.cs
@@ -580,7 +580,7 @@ internal sealed class Host : IHost
 
             [bold]Run [olive]{tool.OriginalName}[/] from [olive]{tool.ServerName}[/] (MCP server)[/]
 
-            {tool.Description}
+            {tool.Description.EscapeMarkup()}
 
             Input:{(hasArgs ? string.Empty : " <none>")}
             """);


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Tool description may contain characters like `"[]"`, which will result in malformed `Markup` object because the square brackets characters have special meaning in markup language.

The `set_config_value` tool from the MCP server `desktop-commander` is an example of this bug -- it has `"empty array ([])"` in its description.

The fix is to escape tool description to avoid malformed 'Markup' object.
