### PR TITLE
Keep the original casing of model name for custom endpoint to enable Foundry Local

### DIFF
--- a/shell/AIShell.Kernel/Shell.cs
+++ b/shell/AIShell.Kernel/Shell.cs
@@ -694,7 +694,12 @@ internal sealed class Shell : IShell
                     while (ex.InnerException is { })
                     {
                         sb ??= new(message, capacity: message.Length * 3);
-                        sb.Append($"\n   Inner -> {ex.InnerException.Message}");
+                        if (sb[^1] is not '\n')
+                        {
+                            sb.Append('\n');
+                        }
+
+                        sb.Append($"   Inner -> {ex.InnerException.Message}");
                         ex = ex.InnerException;
                     }
 
@@ -703,8 +708,9 @@ internal sealed class Shell : IShell
                         message = sb.ToString();
                     }
 
+                    string separator = message.EndsWith('\n') ? "\n" : "\n\n";
                     Host.WriteErrorLine()
-                        .WriteErrorLine($"Agent failed to generate a response: {message}\n\n{stackTrace}")
+                        .WriteErrorLine($"Agent failed to generate a response: {message}{separator}{stackTrace}")
                         .WriteErrorLine();
                 }
             }

--- a/shell/agents/AIShell.OpenAI.Agent/GPT.cs
+++ b/shell/agents/AIShell.OpenAI.Agent/GPT.cs
@@ -55,13 +55,16 @@ public class GPT
         Description = description;
         Endpoint = endpoint?.Trim().TrimEnd('/');
         Deployment = deployment;
-        ModelName = modelName.ToLowerInvariant();
         SystemPrompt = systemPrompt;
         Key = key;
         AuthType = authType;
 
         Dirty = false;
-        ModelInfo = ModelInfo.TryResolve(ModelName, out var model) ? model : null;
+        ModelInfo = ModelInfo.TryResolve(modelName, out var model) ? model : null;
+
+        // OpenAI models require the model name to be lower case. e.g., 'gpt-4.1' works but not 'GPT-4.1'.
+        // However, custom endpoint may be case-sensitive on the model name, such as Foundry Local.
+        ModelName = ModelInfo is { } ? modelName.ToLowerInvariant() : modelName;
 
         bool noEndpoint = string.IsNullOrEmpty(Endpoint);
         bool noDeployment = string.IsNullOrEmpty(Deployment);


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Fix https://github.com/PowerShell/AIShell/issues/410

This PR contains the following 2 fixes:
1. Keep the original casing of the model's name for custom endpoint configuration.
2. Fix the error reporting to handle exception messages that already contains newline at the end.

OpenAI models require lower case for their names, but the custom endpoint may be case-sensitive, such as the endpoint set up by Foundry Local. So, we should keep the original casing for custom endpoint configurations.

### Use Foundry Local with `openai-gpt` agent

1. Update the `openai.agent.json` file with the following GPT configuration:

    ```json
    {
      "GPTs": [
        {
          "Name": "foundry-local",
          "Description": "A GPT instance using Foundry Local.",
          "Endpoint": "http://127.0.0.1:56952/v1",
          "ModelName": "Phi-3.5-mini-instruct-generic-cpu",
          "Key": "OPENAI_API_KEY"
        }
      ]

      "Active": "foundry-local"
    }
    ```

2. In PowerShell, run the following commands to start up the Foundry service and load the model (use `phi-3.5-mini` as an example)
   ```
   PS> foundry service start
   🟢 Service is already running on http://127.0.0.1:56952/.

   PS> foundry model load phi-3.5-mini
   🕔 Loading model...
   🟢 Model phi-3.5-mini loaded successfully

   PS> foundry service ps
   Models running in service:
        Alias                          Model ID
   🟢  phi-3.5-mini                   Phi-3.5-mini-instruct-generic-cpu
   ```

Be noted that:
1. The endpoint to use is the URL shown from `foundry service start` plus `/v1`.
2. The model name to use is shown as the 'Model ID' from the `foundry service ps` command.
    - Make sure you use the exact casing as shown in 'Model ID'. Foundry Local is case-sensitive.
4. The API key is hardcoded to be literally `"OPENAI_API_KEY"`.